### PR TITLE
[Feature-3-4] 유저는 마인드맵에 있는 개별 요소를 클릭하고 아래 삭제 버튼을 통해 삭제할 수 있다.

### DIFF
--- a/client/src/components/MindMapView/index.tsx
+++ b/client/src/components/MindMapView/index.tsx
@@ -1,16 +1,16 @@
 import { Button } from "@headlessui/react";
 import { useEffect, useRef, useState } from "react";
-import { Layer, Rect, Stage } from "react-konva";
+import { Layer, Stage } from "react-konva";
 import plusIcon from "@/assets/plus.png";
 import minusIcon from "@/assets/minus.png";
 import addElementIcon from "@/assets/addElement.png";
 import deleteIcon from "@/assets/trash.png";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import useWindowKeyEventListener from "@/hooks/useWindowKeyEventListener";
-import { DrawNodefromData } from "@/utils/konva_mindmap/node";
+import { DrawNodefromData } from "@/konva_mindmap/node";
+import { NodeData } from "@/types/Node";
 
 export default function MindMapView() {
-  const { data } = useNodeListContext();
   const divRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({
     scale: 1,
@@ -20,7 +20,7 @@ export default function MindMapView() {
     y: 0,
   });
   
-  const { data, updateNodeList, undo, redo } = useNodeListContext();
+  const { data, updateNodeList, updateNodeData, undo, redo } = useNodeListContext();
   const [selectedNode, setSelectedNode] = useState<number | null>(null);
 
   const handleNodeClick = (e: any) => {
@@ -32,7 +32,7 @@ export default function MindMapView() {
     if (selectedNode) {
       setSelectedNode(null);
       const newData = deleteNode({ ...data }, selectedNode);
-      updateNodeList(newData);
+      updateNodeData(newData);
     }
   };
 
@@ -91,7 +91,7 @@ export default function MindMapView() {
         x={dimensions.x}
         y={dimensions.y}
       >
-        <Layer>{DrawNodefromData({ root: data, depth: 1, x: 250, y: 250 })}</Layer>
+        <Layer>{DrawNodefromData({ data: data, root: data[0], depth: data[0].depth, update: updateNodeList, })}</Layer>
       </Stage>
 
       <div className="absolute bottom-2 left-1/2 flex -translate-x-2/4 -translate-y-2/4 items-center gap-3 rounded-full border px-10 py-2 shadow-md">

--- a/client/src/components/MindMapView/index.tsx
+++ b/client/src/components/MindMapView/index.tsx
@@ -8,7 +8,7 @@ import deleteIcon from "@/assets/trash.png";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import useWindowKeyEventListener from "@/hooks/useWindowKeyEventListener";
 import { DrawNodefromData } from "@/konva_mindmap/node";
-import { NodeData } from "@/types/Node";
+import { Node, NodeData } from "@/types/Node";
 
 export default function MindMapView() {
   const divRef = useRef<HTMLDivElement>(null);
@@ -22,6 +22,11 @@ export default function MindMapView() {
   
   const { data, updateNodeList, updateNodeData, undo, redo } = useNodeListContext();
   const [selectedNode, setSelectedNode] = useState<number | null>(null);
+
+  const keyMap = {
+    'z': undo,
+    'y': redo
+  }
 
   const handleNodeClick = (e: any) => {
     const selectedNodeId = Number(e.target.id());
@@ -37,12 +42,10 @@ export default function MindMapView() {
   };
 
   useWindowKeyEventListener("keydown", (e) => {
-    if (e.ctrlKey && e.key === "z") {
-      undo();
-    } else if (e.ctrlKey && e.key === "y") {
-      redo();
+    if (e.ctrlKey && keyMap[e.key]) {
+      keyMap[e.key]();
     }
-  })
+  });
 
   const deleteNode = (nodeData: NodeData, nodeId: number) => {
     if (!nodeData[nodeId]) return;
@@ -50,9 +53,9 @@ export default function MindMapView() {
     children.forEach((childId) => {
       deleteNode(nodeData, childId);
     });
-    for (const node of Object.values(nodeData)) {
+    Object.values(nodeData).forEach((node: Node) => {
       node.children = node.children.filter((childId) => childId !== nodeId);
-    }
+    })
     delete nodeData[nodeId];
     return nodeData;
   }

--- a/client/src/hooks/useHistoryState.ts
+++ b/client/src/hooks/useHistoryState.ts
@@ -1,31 +1,36 @@
 import { useState, useCallback } from "react";
 
 export default function useHistoryState<T>(initialState: T) {
-    const [state, _setState] = useState(initialState);
+    const [data, _setData] = useState(initialState);
     const [history, setHistory] = useState([initialState]);
     const [pointer, setPointer] = useState(0);
 
-    const setState = useCallback(
-        (newState: T) => {
-            const newHistory = [...history.slice(0, pointer + 1), newState];
-            setHistory(newHistory);
+    const setData = useCallback(
+        (newState: T) =>
+            _setData(newState),
+        [pointer, history]
+    );
+
+    const saveHistory = useCallback(
+        () => {
+            const newHistory = [...history.slice(0, pointer + 1), data];
             setPointer(newHistory.length - 1);
-            _setState(newState);
+            setHistory(newHistory);
         },
         [pointer, history]
     );
 
-    const undo: () => void = useCallback(() => {
+    const undo = useCallback(() => {
         if (pointer <= 0) return;
         setPointer((p) => p - 1);
-        _setState(history[pointer - 1]);
+        _setData(history[pointer - 1]);
     }, [history, pointer]);
 
-    const redo: () => void = useCallback(() => {
+    const redo = useCallback(() => {
         if (pointer >= history.length - 1) return;
         setPointer((p) => p + 1);
-        _setState(history[pointer + 1]);
+        _setData(history[pointer + 1]);
     }, [history, pointer]);
 
-    return { state, setState, undo, redo };
+    return { data, setData, saveHistory, undo, redo };
 }

--- a/client/src/hooks/useHistoryState.ts
+++ b/client/src/hooks/useHistoryState.ts
@@ -1,0 +1,31 @@
+import { useState, useCallback } from "react";
+
+export default function useHistoryState<T>(initialState: T) {
+    const [state, _setState] = useState(initialState);
+    const [history, setHistory] = useState([initialState]);
+    const [pointer, setPointer] = useState(0);
+
+    const setState = useCallback(
+        (newState: T) => {
+            const newHistory = [...history.slice(0, pointer + 1), newState];
+            setHistory(newHistory);
+            setPointer(newHistory.length - 1);
+            _setState(newState);
+        },
+        [pointer, history]
+    );
+
+    const undo: () => void = useCallback(() => {
+        if (pointer <= 0) return;
+        setPointer((p) => p - 1);
+        _setState(history[pointer - 1]);
+    }, [history, pointer]);
+
+    const redo: () => void = useCallback(() => {
+        if (pointer >= history.length - 1) return;
+        setPointer((p) => p + 1);
+        _setState(history[pointer + 1]);
+    }, [history, pointer]);
+
+    return { state, setState, undo, redo };
+}

--- a/client/src/hooks/useWindowKeyEventListener.ts
+++ b/client/src/hooks/useWindowKeyEventListener.ts
@@ -1,0 +1,10 @@
+import { useEffect } from "react";
+
+export default function useWindowKeyEventListener(eventType: string, eventHandler: (event: KeyboardEvent) => void) {
+    useEffect(() => {
+        window.addEventListener(eventType, eventHandler);
+        return () => {
+            window.removeEventListener(eventType, eventHandler);
+        };
+    }, [eventType, eventHandler]);
+}

--- a/client/src/store/NodeListProvider.tsx
+++ b/client/src/store/NodeListProvider.tsx
@@ -6,6 +6,7 @@ export type NodeListContextType = {
   data: NodeData | null;
   updateNodeList: (id: number, node: Node) => void;
   updateNodeData: (node: NodeData) => void;
+  saveHistory: (newState: NodeData) => void;
   undo: () => void;
   redo: () => void;
 };
@@ -72,7 +73,7 @@ export function useNodeListContext() {
 }
 
 export default function NodeListProvider({ children }: { children: ReactNode }) {
-  const { state: data, setState: setData, undo, redo } = useHistoryState(nodeData);
+  const { data, setData, saveHistory, undo, redo } = useHistoryState(nodeData);
 
   function updateNodeList(id: number, updatedNode: Node) {
     setData({ ...data, [id]: { ...data?.[id], ...updatedNode } });
@@ -82,5 +83,5 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
     setData(newData);
   }
   
-  return <NodeListContext.Provider value={{ data, updateNodeList, updateNodeData, undo, redo }}>{children}</NodeListContext.Provider>;
+  return <NodeListContext.Provider value={{ data, updateNodeList, updateNodeData, undo, redo, saveHistory }}>{children}</NodeListContext.Provider>;
 }

--- a/client/src/store/NodeListProvider.tsx
+++ b/client/src/store/NodeListProvider.tsx
@@ -1,177 +1,65 @@
-import { Node } from "@/types/Node";
-import { createContext, ReactNode, useContext, useEffect, useState } from "react";
+import useHistoryState from "@/hooks/useHistoryState";
+import { Node, NodeData } from "@/types/Node";
+import { createContext, ReactNode, useContext } from "react";
 
 export type NodeListContextType = {
-  data: Node | null;
-  updateNodeList: (nodeList: Node) => void;
+  data: NodeData | null;
+  updateNodeList: (nodeList: NodeData) => void;
+  undo: () => void;
+  redo: () => void;
 };
 
 const nodeData = {
-  content: "대분류",
-  location: { x: 24.1515, y: 211.214124 },
-  children: [
-    {
-      content: "중분류1",
-      location: { x: 24.1515, y: 211.214124 },
-      children: [
-        {
-          content: "소분류1-1",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-        {
-          content: "소분류1-2",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-      ],
-    },
-    {
-      content: "중분류2",
-      location: { x: 24.1515, y: 211.214124 },
-      children: [
-        {
-          content: "소분류2-1",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-        {
-          content: "소분류2-2",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-      ],
-    },
-    {
-      content: "중분류2",
-      location: { x: 24.1515, y: 211.214124 },
-      children: [
-        {
-          content: "소분류2-1",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-        {
-          content: "소분류2-2",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-      ],
-    },
-    {
-      content: "중분류2",
-      location: { x: 24.1515, y: 211.214124 },
-      children: [
-        {
-          content: "소분류2-1",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-        {
-          content: "소분류2-2",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-      ],
-    },
-    {
-      content: "중분류2",
-      location: { x: 24.1515, y: 211.214124 },
-      children: [
-        {
-          content: "소분류2-1",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-        {
-          content: "소분류2-2",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-      ],
-    },
-    {
-      content: "중분류2",
-      location: { x: 24.1515, y: 211.214124 },
-      children: [
-        {
-          content: "소분류2-1",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-        {
-          content: "소분류2-2",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-      ],
-    },
-    {
-      content: "중분류2",
-      location: { x: 24.1515, y: 211.214124 },
-      children: [
-        {
-          content: "소분류2-1",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-        {
-          content: "소분류2-2",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-      ],
-    },
-    {
-      content: "중분류2",
-      location: { x: 24.1515, y: 211.214124 },
-      children: [
-        {
-          content: "소분류2-1",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-        {
-          content: "소분류2-2",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-      ],
-    },
-    {
-      content: "중분류2",
-      location: { x: 24.1515, y: 211.214124 },
-      children: [
-        {
-          content: "소분류2-1",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-        {
-          content: "소분류2-2",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-      ],
-    },
-    {
-      content: "중분류2",
-      location: { x: 24.1515, y: 211.214124 },
-      children: [
-        {
-          content: "소분류2-1",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-        {
-          content: "소분류2-2",
-          location: { x: 24.1515, y: 211.214124 },
-          children: [],
-        },
-      ],
-    },
-  ],
-};
+	1 : {
+		"id": 1,
+		"keyword" : "점심메뉴",
+		"depth" : 1,
+		"location": { "x" : 24.1515, "y": 211.214124 },
+		"children": [2, 3]
+	},
+	2 : {
+		"id": 2,
+		"keyword" : "양식",
+		"depth" : 2,
+		"location": { "x" : 24.1515, "y": 211.214124 },
+		"children": [4, 5]
+	},
+	3 : {
+		"id": 3,
+		"depth" : 2,
+		"keyword" : "한식",
+		"location": { "x" : 24.1515, "y": 211.214124 },
+		"children": [6, 7]
+	},
+	4 : {
+		"id": 4,
+		"depth" : 3,
+		"keyword" : "면",
+		"location": { "x" : 24.1515, "y": 211.214124 },
+		"children": []
+	},
+	5 : {
+		"id": 5,
+		"depth" : 3,
+		"keyword" : "밥",
+		"location": { "x" : 24.1515, "y": 211.214124 },
+		"children": []
+	},
+	6 : {
+		"id": 6,
+		"depth" : 3,
+		"keyword" : "고기",
+		"location": { "x" : 24.1515, "y": 211.214124 },
+		"children": []
+	},
+	7 : {
+		"id": 7,
+		"depth" : 3,
+		"keyword" : "찌개",
+		"location": { "x" : 24.1515, "y": 211.214124 },
+		"children": []
+	},
+}
 
 const NodeListContext = createContext<NodeListContextType | undefined>(undefined);
 export function useNodeListContext() {
@@ -183,11 +71,11 @@ export function useNodeListContext() {
 }
 
 export default function NodeListProvider({ children }: { children: ReactNode }) {
-  const [data, setData] = useState<Node>(nodeData);
+  const { state: data, setState: setData, undo, redo } = useHistoryState<NodeData>(nodeData);
 
   function updateNodeList(nodeList: Node) {
     setData(nodeList);
   }
 
-  return <NodeListContext.Provider value={{ data, updateNodeList }}>{children}</NodeListContext.Provider>;
+  return <NodeListContext.Provider value={{ data, updateNodeList, undo, redo }}>{children}</NodeListContext.Provider>;
 }

--- a/client/src/store/NodeListProvider.tsx
+++ b/client/src/store/NodeListProvider.tsx
@@ -1,15 +1,16 @@
 import useHistoryState from "@/hooks/useHistoryState";
-import { Node } from "@/types/Node";
+import { Node, NodeData } from "@/types/Node";
 import { createContext, ReactNode, useContext, useState } from "react";
         
 export type NodeListContextType = {
   data: NodeData | null;
-  updateNodeList: (nodeList: NodeData) => void;
+  updateNodeList: (id: number, node: Node) => void;
+  updateNodeData: (node: NodeData) => void;
   undo: () => void;
   redo: () => void;
 };
 
-const nodeData = {
+const nodeData: NodeData = {
   1: {
     id: 1,
     keyword: "점심메뉴",
@@ -71,11 +72,15 @@ export function useNodeListContext() {
 }
 
 export default function NodeListProvider({ children }: { children: ReactNode }) {
-  const { state: data, setState: setData, undo, redo } = useHistoryState<NodeData>(nodeData);
+  const { state: data, setState: setData, undo, redo } = useHistoryState(nodeData);
 
   function updateNodeList(id: number, updatedNode: Node) {
-    setData((prevData) => prevData.map((node) => (node.id === id ? { ...node, ...updatedNode } : node)));
+    setData({ ...data, [id]: { ...data?.[id], ...updatedNode } });
   }
 
-  return <NodeListContext.Provider value={{ data, updateNodeList, undo, redo }}>{children}</NodeListContext.Provider>;
+  function updateNodeData(newData: NodeData) {
+    setData(newData);
+  }
+  
+  return <NodeListContext.Provider value={{ data, updateNodeList, updateNodeData, undo, redo }}>{children}</NodeListContext.Provider>;
 }

--- a/client/src/types/Node.ts
+++ b/client/src/types/Node.ts
@@ -1,5 +1,12 @@
 export type Node = {
-  content: string;
-  location: { x: number; y: number };
-  children: Node[] | [];
+  id: number;
+  keyword: string;
+  depth: number;
+  location: {
+    x: number;
+    y: number;
+  };
+  children: number[];
 };
+
+export type NodeData = Record<number, Node>;


### PR DESCRIPTION
#25 

## 작업 내용

### useHistoryState 커스텀 훅 정의
- 특정 상태의 history를 관리할 수 있도록 만들어 줍니다.
- `undo` 함수를 통해 이전 상태로 돌아갈 수 있고, `redo` 함수를 통해 앞으로 가기 기능을 사용할 수 있습니다.

### useWindowKeyEventListener 커스텀 훅 정의
- window에 KeyBoard 관련 이벤트를 정의할 수 있습니다. 이벤트 종류(string)와 핸들러 함수를 전달하면 전역에 등록해 줍니다.

### 캔버스에서 특정 요소를 클릭하여 선택할 수 있음


## 논의하고 싶은 내용
### history 업데이트 시점
지금은 `useHistoryState`로 관리되는 상태가 업데이트되면 바로 history에 저장되고 있는데, 리팩토링을 통해 history에 상태 저장을 트리거하는 함수를 따로 두어야 합니다. (ex. 유저가 요소를 드래그하고 있을 때 매번 상태가 변경이 되는데, 이를 모두 history에 저장하지 않고 유저가 드래그 액션을 끝냈을 때 해당 값만 history에 등록되도록) 해당 작업은 다른 로직들과의 통합 이후에 진행하도록 하겠습니다.
