### PR TITLE
[Feature-3-10-fe] 유저는 마인드맵을 확대, 축소 시키거나 드래그 앤 드랍으로 포커스를 바꿀 수 있다.

### DIFF
--- a/client/src/components/MindMapView/index.tsx
+++ b/client/src/components/MindMapView/index.tsx
@@ -90,6 +90,7 @@ export default function MindMapView() {
   return (
     <div ref={divRef} className="relative h-full min-h-0 w-full min-w-0 rounded-xl bg-white">
       <Stage
+        className="cursor-pointer"
         width={dimensions.width}
         height={dimensions.height}
         scaleX={dimensions.scale}

--- a/client/src/components/MindMapView/index.tsx
+++ b/client/src/components/MindMapView/index.tsx
@@ -8,10 +8,10 @@ import deleteIcon from "@/assets/trash.png";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { DrawNodefromData } from "@/konva_mindmap/node";
 import { checkCollision } from "@/konva_mindmap/utils/collision";
-import Konva from "konva";
 import useWindowKeyEventListener from "@/hooks/useWindowKeyEventListener";
 import { Node, NodeData } from "@/types/Node";
 import useLayerEvent from "@/konva_mindmap/hooks/useLayerEvent";
+import { ratioSizing } from "@/konva_mindmap/events/ratioSizing";
 
 export default function MindMapView() {
   const { data, updateNodeList, updateNodeData, undo, redo } = useNodeListContext();
@@ -96,6 +96,8 @@ export default function MindMapView() {
         scaleY={dimensions.scale}
         x={dimensions.x}
         y={dimensions.y}
+        draggable
+        onWheel={(e) => ratioSizing(e, dimensions, setDimensions)}
       >
         <Layer ref={layer}>
           {DrawNodefromData({ data: data, root: data[1], depth: data[1].depth, update: updateNodeList })}
@@ -107,7 +109,7 @@ export default function MindMapView() {
           <Button className="h-5 w-5">
             <img src={plusIcon} alt="확대하기" />
           </Button>
-          <span className="text-sm font-bold text-black">{dimensions.scale * 100}%</span>
+          <span className="text-sm font-bold text-black">{Math.floor(dimensions.scale * 100)}%</span>
           <Button className="h-5 w-5">
             <img src={minusIcon} alt="축소하기" />
           </Button>

--- a/client/src/components/MindMapView/index.tsx
+++ b/client/src/components/MindMapView/index.tsx
@@ -100,9 +100,7 @@ export default function MindMapView() {
         draggable
         onWheel={(e) => ratioSizing(e, dimensions, setDimensions)}
       >
-        <Layer ref={layer}>
-          {DrawNodefromData({ data: data, root: data[1], depth: data[1].depth, update: updateNodeList })}
-        </Layer>
+        <Layer ref={layer}>{DrawNodefromData({ data: data, root: data[1], depth: data[1].depth })}</Layer>
       </Stage>
 
       <div className="absolute bottom-2 left-1/2 flex -translate-x-2/4 -translate-y-2/4 items-center gap-3 rounded-full border px-10 py-2 shadow-md">

--- a/client/src/konva_mindmap/events/ratioSizing.ts
+++ b/client/src/konva_mindmap/events/ratioSizing.ts
@@ -1,0 +1,30 @@
+export function ratioSizing(e, dimensions, setDimensions) {
+  e.evt.preventDefault();
+
+  const scaleBy = 1.02;
+  const stage = e.target.getStage();
+  const oldScale = stage.attrs.scaleX;
+  const pointer = stage.getPointerPosition();
+  console.log(oldScale, pointer, stage.x(), stage.y());
+  const mousePointTo = {
+    // 포인터가 가르키는 x,y좌표를 기존 확대비율로 나눈 것에 stage의 x좌표에 기존 확대비율로 나눈 값을 뻄
+    x: pointer.x / oldScale - stage.x() / oldScale,
+    y: pointer.y / oldScale - stage.y() / oldScale,
+  };
+
+  // 새로운 비율을 deltaY가 0보다 작게 되면 기존 값에 1.02만큼 곱한 값을, 아니면 기존 값에 1.02만큼 나눈 값으로 설정
+  // deltaY는 사용자가 휠을 스크롤한 양임
+  // 위로 스크롤하면 양수, 아래로 스크롤하면 음수
+  const newScale = e.evt.deltaY < 0 ? oldScale * scaleBy : oldScale / scaleBy;
+  const newPos = {
+    x: pointer.x - mousePointTo.x * newScale,
+    y: pointer.y - mousePointTo.y * newScale,
+  };
+
+  setDimensions({
+    ...dimensions,
+    scale: newScale,
+    x: newPos.x,
+    y: newPos.y,
+  });
+}

--- a/client/src/konva_mindmap/node.tsx
+++ b/client/src/konva_mindmap/node.tsx
@@ -1,23 +1,24 @@
 import { Node, NodeData } from "@/types/Node";
 import { ConnectedLine } from "@/konva_mindmap/ConnectedLine";
 import { Circle, Group, Text } from "react-konva";
+import { useNodeListContext } from "@/store/NodeListProvider";
 
 type NodeProps = {
   parentNode?: Node;
   node: Node;
   depth: number;
   text: string;
-  updateNode: (id: number, updatedNode: Node) => void;
 };
 
-function NodeComponent({ parentNode, node, depth, text, updateNode }: NodeProps) {
+function NodeComponent({ parentNode, node, depth, text }: NodeProps) {
+  const { updateNodeList } = useNodeListContext();
   return (
     <>
       <Group
         name="node"
         id={node.id.toString()}
         onDragMove={(e) => {
-          updateNode(node.id, {
+          updateNodeList(node.id, {
             ...node,
             location: {
               x: e.target.x(),
@@ -26,7 +27,7 @@ function NodeComponent({ parentNode, node, depth, text, updateNode }: NodeProps)
           });
         }}
         onDragEnd={(e) =>
-          updateNode(node.id, {
+          updateNodeList(node.id, {
             ...node,
             location: {
               x: e.target.x(),
@@ -61,21 +62,14 @@ type DrawNodeProps = {
   update?: (id: number, node: Node) => void;
 };
 
-export function DrawNodefromData({ data, root, depth = 0, parentNode, update }: DrawNodeProps) {
+export function DrawNodefromData({ data, root, depth = 0, parentNode }: DrawNodeProps) {
   return (
     <>
       {/* from */}
-      <NodeComponent text={root.keyword} depth={depth} parentNode={parentNode} node={root} updateNode={update} />
+      <NodeComponent text={root.keyword} depth={depth} parentNode={parentNode} node={root} />
       {/* to */}
       {root.children?.map((childNode, index) => (
-        <DrawNodefromData
-          data={data}
-          key={index}
-          root={data[childNode]}
-          depth={depth + 1}
-          parentNode={root}
-          update={update}
-        />
+        <DrawNodefromData data={data} key={index} root={data[childNode]} depth={depth + 1} parentNode={root} />
       ))}
     </>
   );


### PR DESCRIPTION
[#68](https://github.com/boostcampwm-2024/web32-BooMap/issues/68)
작업 내용
해당 PR은 3-8-fe 머지 이후에 머지 바랍니당

* 마인드맵 확대 및 축소를 마인드맵 위에 커서를 두고 휠을 돌리면 가능하도록 이벤트 구현 및 핸들러 등록
* 마인드맵의 stage에 draggable 속성을 주어 드래그 앤 드롭으로 마인드맵 포커스 변경
논의하고 싶은 내용