### PR TITLE
[Feature-3-5-fe] 유저는 마인드맵에 있는 개별 요소를 더블클릭을 하면 수정할 수 있다.

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-konva": "^18.2.10",
+        "react-konva-utils": "^1.0.6",
         "react-router-dom": "^6.27.0",
         "zustand": "^5.0.1"
       },
@@ -6762,6 +6763,21 @@
         "react-dom": ">=18.0.0"
       }
     },
+    "node_modules/react-konva-utils": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/react-konva-utils/-/react-konva-utils-1.0.6.tgz",
+      "integrity": "sha512-011+jyXwadFDkbIUdlTarKwbqME0ljX1vPeW5oyLQx4rtHdcsDr43tdOdSsMT3XpZyl8clgM9I/eK0lBuBuFHg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-konva": "^18.0.0-0",
+        "use-image": "^1.1.0"
+      },
+      "peerDependencies": {
+        "konva": "^8.3.5 || ^9.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
     "node_modules/react-reconciler": {
       "version": "0.29.2",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
@@ -8227,6 +8243,16 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-image": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-image/-/use-image-1.1.1.tgz",
+      "integrity": "sha512-n4YO2k8AJG/BcDtxmBx8Aa+47kxY5m335dJiCQA5tTeVU4XdhrhqR6wT0WISRXwdMEOv5CSjqekDZkEMiiWaYQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-konva": "^18.2.10",
+    "react-konva-utils": "^1.0.6",
     "react-router-dom": "^6.27.0",
     "zustand": "^5.0.1"
   },

--- a/client/src/konva_mindmap/EditableText.tsx
+++ b/client/src/konva_mindmap/EditableText.tsx
@@ -23,6 +23,7 @@ export default function EditableText({
   offsetY,
   width,
 }: EditableTextProps) {
+  const [originalContent] = useState(text);
   const [content, setContent] = useState(text);
   const { data, updateNodeList } = useNodeListContext();
 
@@ -31,10 +32,9 @@ export default function EditableText({
   }
 
   function saveContent() {
-    if (content.trim() !== "") {
-      updateNodeList(id, { ...data[id], keyword: content });
-      setIsEditing(false);
-    }
+    if (content.trim() !== "") updateNodeList(id, { ...data[id], keyword: content });
+    else setContent(originalContent);
+    setIsEditing(false);
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {

--- a/client/src/konva_mindmap/EditableText.tsx
+++ b/client/src/konva_mindmap/EditableText.tsx
@@ -48,7 +48,15 @@ export default function EditableText({
   return (
     <>
       {isEditing ? (
-        <EditableTextInput value={content} onChange={handleTextChange} onKeyDown={handleKeyDown} onBlur={handleBlur} />
+        <EditableTextInput
+          value={content}
+          onChange={handleTextChange}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          offsetX={offsetX}
+          offsetY={offsetY}
+          width={width}
+        />
       ) : (
         <Text
           text={content}

--- a/client/src/konva_mindmap/EditableText.tsx
+++ b/client/src/konva_mindmap/EditableText.tsx
@@ -9,9 +9,20 @@ interface EditableTextProps {
   name: string;
   isEditing: boolean;
   setIsEditing: (isEditing: boolean) => void;
+  offsetX: number;
+  offsetY: number;
+  width: number;
 }
 
-export default function EditableText({ id, text, isEditing, setIsEditing }: EditableTextProps) {
+export default function EditableText({
+  id,
+  text,
+  isEditing,
+  setIsEditing,
+  offsetX,
+  offsetY,
+  width,
+}: EditableTextProps) {
   const [content, setContent] = useState(text);
   const { data, updateNodeList } = useNodeListContext();
 
@@ -39,7 +50,16 @@ export default function EditableText({ id, text, isEditing, setIsEditing }: Edit
       {isEditing ? (
         <EditableTextInput value={content} onChange={handleTextChange} onKeyDown={handleKeyDown} onBlur={handleBlur} />
       ) : (
-        <Text text={content} fill="black" width={80} />
+        <Text
+          text={content}
+          fill="black"
+          wrap="word"
+          align="center"
+          fontStyle="bold"
+          offsetX={offsetX}
+          offsetY={offsetY}
+          width={width}
+        />
       )}
     </>
   );

--- a/client/src/konva_mindmap/EditableText.tsx
+++ b/client/src/konva_mindmap/EditableText.tsx
@@ -23,7 +23,7 @@ export default function EditableText({
   offsetY,
   width,
 }: EditableTextProps) {
-  const [originalContent] = useState(text);
+  const originalContent = text;
   const [content, setContent] = useState(text);
   const { data, updateNodeList } = useNodeListContext();
 
@@ -32,7 +32,7 @@ export default function EditableText({
   }
 
   function saveContent() {
-    if (content.trim() !== "") updateNodeList(id, { ...data[id], keyword: content });
+    if (content.trim().length) updateNodeList(id, { ...data[id], keyword: content });
     else setContent(originalContent);
     setIsEditing(false);
   }

--- a/client/src/konva_mindmap/EditableText.tsx
+++ b/client/src/konva_mindmap/EditableText.tsx
@@ -1,0 +1,46 @@
+import EditableTextInput from "./EditableTextInput";
+import { Text } from "react-konva";
+import { useState } from "react";
+import { useNodeListContext } from "@/store/NodeListProvider";
+
+interface EditableTextProps {
+  id: number;
+  text: string;
+  name: string;
+  isEditing: boolean;
+  setIsEditing: (isEditing: boolean) => void;
+}
+
+export default function EditableText({ id, text, isEditing, setIsEditing }: EditableTextProps) {
+  const [content, setContent] = useState(text);
+  const { data, updateNodeList } = useNodeListContext();
+
+  function handleTextChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setContent(e.target.value);
+  }
+
+  function saveContent() {
+    if (content.trim() !== "") {
+      updateNodeList(id, { ...data[id], keyword: content });
+      setIsEditing(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") saveContent();
+  }
+
+  function handleBlur() {
+    saveContent();
+  }
+
+  return (
+    <>
+      {isEditing ? (
+        <EditableTextInput value={content} onChange={handleTextChange} onKeyDown={handleKeyDown} onBlur={handleBlur} />
+      ) : (
+        <Text text={content} fill="black" width={80} />
+      )}
+    </>
+  );
+}

--- a/client/src/konva_mindmap/EditableTextInput.tsx
+++ b/client/src/konva_mindmap/EditableTextInput.tsx
@@ -13,7 +13,7 @@ export default function EditableTextInput({ value, onChange, onKeyDown, onBlur }
       <input
         value={value}
         onChange={onChange}
-        className={`w-full resize-none bg-transparent text-xs text-grayscale-800 ${value.trim() === "" ? "border border-red-500" : ""}`}
+        className={`w-full resize-none bg-transparent text-sm font-semibold text-black ${value.trim() === "" ? "border border-red-500" : ""}`}
         onKeyDown={onKeyDown}
         onBlur={onBlur}
         maxLength={14}

--- a/client/src/konva_mindmap/EditableTextInput.tsx
+++ b/client/src/konva_mindmap/EditableTextInput.tsx
@@ -5,18 +5,30 @@ interface EditableTextInputProps {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   onBlur: () => void;
+  offsetX: number;
+  offsetY: number;
+  width: number;
 }
 
-export default function EditableTextInput({ value, onChange, onKeyDown, onBlur }: EditableTextInputProps) {
+export default function EditableTextInput({
+  value,
+  onChange,
+  onKeyDown,
+  onBlur,
+  offsetX,
+  offsetY,
+  width,
+}: EditableTextInputProps) {
   return (
-    <Html>
+    <Html groupProps={{ offset: { x: offsetX, y: offsetY } }}>
       <input
         value={value}
         onChange={onChange}
-        className={`w-full resize-none bg-transparent text-sm font-semibold text-black ${value.trim() === "" ? "border border-red-500" : ""}`}
+        className={`w-full resize-none bg-transparent text-center text-sm font-semibold text-black ${value.trim() === "" ? "border border-red-500" : ""}`}
         onKeyDown={onKeyDown}
         onBlur={onBlur}
         maxLength={14}
+        style={{ width }}
       />
     </Html>
   );

--- a/client/src/konva_mindmap/EditableTextInput.tsx
+++ b/client/src/konva_mindmap/EditableTextInput.tsx
@@ -1,0 +1,23 @@
+import { Html } from "react-konva-utils";
+
+interface EditableTextInputProps {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onBlur: () => void;
+}
+
+export default function EditableTextInput({ value, onChange, onKeyDown, onBlur }: EditableTextInputProps) {
+  return (
+    <Html>
+      <input
+        value={value}
+        onChange={onChange}
+        className={`w-full resize-none bg-transparent text-xs text-grayscale-800 ${value.trim() === "" ? "border border-red-500" : ""}`}
+        onKeyDown={onKeyDown}
+        onBlur={onBlur}
+        maxLength={14}
+      />
+    </Html>
+  );
+}

--- a/client/src/konva_mindmap/EditableTextInput.tsx
+++ b/client/src/konva_mindmap/EditableTextInput.tsx
@@ -22,6 +22,7 @@ export default function EditableTextInput({
   return (
     <Html groupProps={{ offset: { x: offsetX, y: offsetY } }}>
       <input
+        autoFocus={true}
         value={value}
         onChange={onChange}
         className={`w-full resize-none bg-transparent text-center text-sm font-semibold text-black ${value.trim() === "" ? "border border-red-500" : ""}`}

--- a/client/src/konva_mindmap/node.tsx
+++ b/client/src/konva_mindmap/node.tsx
@@ -59,16 +59,15 @@ function NodeComponent({ parentNode, node, depth, text }: NodeProps) {
         y={node.location.y}
       >
         <Circle fill={colors[depth - 1]} width={100} height={100} radius={60 - depth * 10} />
-        <Text
+        <EditableText
+          id={node.id}
           name="text"
           text={text}
-          color="black"
-          fontStyle="bold"
           offsetX={70 - depth * 10}
           offsetY={8 * depth - 60}
           width={140 - depth * 20}
-          wrap="word"
-          align="center"
+          isEditing={isEditing}
+          setIsEditing={setIsEditing}
         />
       </Group>
     </>

--- a/client/src/konva_mindmap/node.tsx
+++ b/client/src/konva_mindmap/node.tsx
@@ -1,7 +1,9 @@
 import { Node, NodeData } from "@/types/Node";
 import { ConnectedLine } from "@/konva_mindmap/ConnectedLine";
-import { Circle, Group, Text } from "react-konva";
+import { Circle, Group } from "react-konva";
 import { useNodeListContext } from "@/store/NodeListProvider";
+import { useState } from "react";
+import EditableText from "./EditableText";
 
 type NodeProps = {
   parentNode?: Node;
@@ -14,6 +16,12 @@ const colors = ["skyblue", "lightgreen", "lightcoral"];
 
 function NodeComponent({ parentNode, node, depth, text }: NodeProps) {
   const { updateNodeList } = useNodeListContext();
+  const [isEditing, setIsEditing] = useState(false);
+
+  function handleDoubleClick() {
+    setIsEditing(true);
+  }
+
   return (
     <>
       {parentNode && (
@@ -25,6 +33,7 @@ function NodeComponent({ parentNode, node, depth, text }: NodeProps) {
         />
       )}
       <Group
+        onDblClick={handleDoubleClick}
         name="node"
         id={node.id.toString()}
         onDragMove={(e) => {


### PR DESCRIPTION
#30 

## 작업 내용
https://github.com/user-attachments/assets/f175d893-2367-4e32-a57d-a38dbce097f8

### 의존성 설치
- `react-konva-utils`를 설치했습니다. [레포링크](https://github.com/konvajs/react-konva-utils)
- canvas 위에서 간단하게 html 요소를 사용할 수 있게 해 줍니다. 저는 input을 쓰기 위해 설치했습니다.

### 마인드맵 요소를 더블클릭 하면 텍스트가 input으로 변경
- 마인드맵의 요소 (원 또는 텍스트)를 더블클릭할 경우, 해당 텍스트가 input으로 변경됩니다.
- 이를 위해 `EditableText`, `EditableTextInput` 두 가지 컴포넌트를 정의했습니다.
    - `EditableText`는 `isEditing` 여부에 따라 input이나 `Text`를 보여 줍니다
    - `EditableTextInput`은 input을 사용하여 사용자의 입력을 받고 변경사항을 감지합니다

### 요소 수정 후 blur 또는 엔터를 입력하면 변경사항 반영
- 요소를 input으로 만들어 수정한 다음, 엔터키를 누르거나 해당 input 외부 영역을 클릭하면 변경사항이 반영됩니다.
- 이때 input 안에 내용이 없을 경우 input이 비활성화되지 않고, 빨간색 테두리가 생기도록 했습니다.


## 논의하고 싶은 내용
### `EditableText`와 `EditableTextInput`의 위치 불일치
- 영상에도 들어가 있지만 input이 활성화되면 텍스트의 위치가 좌측 위쪽으로 이동합니다. `EditableTextInput`에게 `offset` 값이 전달되지 않아서 발생하는 문제인데, `EditableTextInput`에서 `groupProps`로 `offset` 값을 줘 봐도 어째서인지 잘 동작하지 않았습니다... (시도했던 코드는 아래 참고)
```javascript
export default function EditableTextInput({
  value,
  onChange,
  onKeyDown,
  onBlur,
  offsetX,
  offsetY,
}: EditableTextInputProps) {
  return (
    <Html groupProps={{ offset: { x: offsetX, y: offsetY } }}>
```

### input 줄바꿈
- 뭔가 text처럼 input에서 입력을 할 때도 자동 줄바꿈이 되게 하고 싶었는데, textarea와 useRef를 써 봐도... input을 써 봐도... 마음처럼 잘 되지 않습니다 ㅠㅠ
