### PR TITLE
[Feature-3-jjambbong2] 노드 조작 관련 기능 결합 및 신규 기능 추가

### DIFF
--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -4,9 +4,17 @@ import shareIcon from "@/assets/share.png";
 import exportIcon from "@/assets/export.png";
 import useModal from "@/hooks/useModal";
 import LoginModal from "@/components/LoginModal";
+import { useStageStore } from "@/store/useStageStore";
+import { downloadURI } from "@/konva_mindmap/utils/download";
+import { useSearchParams } from "react-router-dom";
 
 export default function Header() {
+  const mode = useSearchParams();
   const { open, openModal, closeModal } = useModal();
+  const stage = useStageStore((state) => state.stage);
+  function handleExport() {
+    downloadURI(stage.current.getStage().toDataURL({ mimeType: "image/png", quality: 1 }), "demo");
+  }
   return (
     <header className="flex w-full justify-between bg-grayscale-700 p-4">
       <div className="flex gap-5">
@@ -14,7 +22,10 @@ export default function Header() {
           <img src={shareIcon} alt="공유하기" className="w-5" />
           Share
         </Button>
-        <Button className="flex items-center gap-3 rounded-lg bg-grayscale-600 px-5 text-grayscale-100">
+        <Button
+          className="flex items-center gap-3 rounded-lg bg-grayscale-600 px-5 text-grayscale-100"
+          onClick={handleExport}
+        >
           <img src={exportIcon} alt="내보내기" className="w-5" />
           Export
         </Button>

--- a/client/src/components/MainSection/ControlSection/ListView/NodeItem.tsx
+++ b/client/src/components/MainSection/ControlSection/ListView/NodeItem.tsx
@@ -34,7 +34,8 @@ export default function NodeItem({ node, parentNodeId, open, handleAccordion, op
   } = useNodeActions(node.id, node.keyword);
   const { data, saveHistory, selectedNode, overrideNodeData, selectNode } = useNodeListContext();
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const isSelected = selectedNode.parentNodeId === node.id;
+  const isSelected =
+    selectedNode.parentNodeId === node.id || findParentNodeId(selectedNode.parentNodeId, data) === node.id;
 
   useEffect(() => {
     if (node.newNode) {
@@ -46,6 +47,16 @@ export default function NodeItem({ node, parentNodeId, open, handleAccordion, op
   useEffect(() => {
     if (isSelected) openAccordion();
   }, [isSelected]);
+
+  function findParentNodeId(nodeId, nodeData) {
+    for (const id in nodeData) {
+      const node = nodeData[parseInt(id)];
+      if (node.children.includes(nodeId)) {
+        return node.id;
+      }
+    }
+    return null;
+  }
 
   function handleAddButton() {
     saveHistory(JSON.stringify(data));

--- a/client/src/components/MainSection/ControlSection/ListView/NodeItem.tsx
+++ b/client/src/components/MainSection/ControlSection/ListView/NodeItem.tsx
@@ -7,28 +7,19 @@ import useNodeActions from "@/hooks/useNodeActions";
 import bulletPointIcon from "@/assets/bulletPoint.png";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { deleteNode } from "@/konva_mindmap/events/deleteNode";
-import { addNode } from "@/konva_mindmap/events/addNode";
+import { addNode, showNewNode } from "@/konva_mindmap/events/addNode";
 import { useEffect, useRef } from "react";
+import { Node } from "@/types/Node";
 
 type NodeItemProps = {
-  id: number;
+  node: Node;
   parentNodeId?: number;
-  content: string;
-  depth: number;
   open: boolean;
   handleAccordion: () => void;
   openAccordion: () => void;
 };
 
-export default function NodeItem({
-  id,
-  parentNodeId,
-  content,
-  depth,
-  open,
-  handleAccordion,
-  openAccordion,
-}: NodeItemProps) {
+export default function NodeItem({ node, parentNodeId, open, handleAccordion, openAccordion }: NodeItemProps) {
   const {
     hover,
     isEditing,
@@ -40,55 +31,45 @@ export default function NodeItem({
     handleMouseEnter,
     handleMouseLeave,
     handleKeyDown,
-  } = useNodeActions(id, content);
-  const { data, saveHistory, selectedNode, overrideNodeData, focusNodeId, updateFocusNodeId } = useNodeListContext();
+  } = useNodeActions(node.id, node.keyword);
+  const { data, saveHistory, selectedNode, overrideNodeData, selectNode } = useNodeListContext();
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const isSelected = selectedNode.parentNodeId === id || findParentNodeId(selectedNode.parentNodeId, data) === id;
+  const isSelected = selectedNode.parentNodeId === node.id;
 
   useEffect(() => {
-    if (id === focusNodeId) {
+    if (node.newNode) {
       setIsEditing(true);
       inputRef.current?.focus();
     }
-  }, [id, focusNodeId, setIsEditing]);
+  }, [node.id, setIsEditing]);
 
   useEffect(() => {
     if (isSelected) openAccordion();
   }, [isSelected]);
 
-  function findParentNodeId(nodeId, nodeData) {
-    for (const id in nodeData) {
-      const node = nodeData[parseInt(id)];
-      if (node.children.includes(nodeId)) {
-        return node.id;
-      }
-    }
-    return null;
-  }
-
   function handleAddButton() {
     saveHistory(JSON.stringify(data));
-    const nodeId = addNode(data, { nodeId: id, parentNodeId: parentNodeId }, overrideNodeData);
-    updateFocusNodeId(nodeId);
+    selectNode({ nodeId: node.id, parentNodeId: parentNodeId });
+    showNewNode(data, { nodeId: node.id, parentNodeId: parentNodeId }, overrideNodeData);
     openAccordion();
   }
 
   function handleDeleteButton() {
     saveHistory(JSON.stringify(data));
-    deleteNode(JSON.stringify(data), id, overrideNodeData);
+    deleteNode(JSON.stringify(data), node.id, overrideNodeData);
   }
 
-  const selectedBorder = selectedNode.nodeId === id ? "border-2 border-blue-500" : "border-2 border-grayscale-600";
+  const selectedBorder = selectedNode.nodeId === node.id ? "border-2 border-blue-500" : "border-2 border-grayscale-600";
 
   return (
     <div
       className={`flex justify-between rounded-xl bg-grayscale-600 p-[10px] ${selectedBorder}`}
-      style={{ marginLeft: `${(depth - 1) * 30}px` }}
+      style={{ marginLeft: `${(node.depth - 1) * 30}px` }}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
       <div className="flex min-w-0 flex-1 items-center gap-3">
-        {depth < 3 ? (
+        {node.depth < 3 ? (
           <button
             className={`flex h-5 w-5 items-center justify-center transition-all ${open ? "" : "rotate-[-90deg]"}`}
             onClick={handleAccordion}
@@ -121,7 +102,7 @@ export default function NodeItem({
             <button onClick={() => setIsEditing(true)}>
               <img src={editIcon} alt="수정하기" className="h-4 w-4" />
             </button>
-            {depth < 3 ? (
+            {node.depth < 3 ? (
               <button onClick={handleAddButton}>
                 <img src={plusIcon} alt="추가하기" className="h-4 w-4" />
               </button>

--- a/client/src/components/MainSection/ControlSection/ListView/NodeList.tsx
+++ b/client/src/components/MainSection/ControlSection/ListView/NodeList.tsx
@@ -1,33 +1,28 @@
 import NodeItem from "@/components/MainSection/ControlSection/ListView/NodeItem";
 import useAccordion from "@/hooks/useAccordion";
-import { useNodeListContext } from "@/store/NodeListProvider";
-import { NodeData } from "@/types/Node";
-import { useEffect } from "react";
+import { Node, NodeData } from "@/types/Node";
 
 type NodeListProps = {
   data: NodeData;
   parentNodeId?: number;
-  id: number;
+  root: Node;
 };
 
-export default function NodeList({ data, parentNodeId, id }: NodeListProps) {
-  const nodeData = data[id];
+export default function NodeList({ data, parentNodeId, root }: NodeListProps) {
   const { open, handleAccordion, openAccordion } = useAccordion();
 
   return (
     <div className="flex h-full flex-col gap-2">
       <NodeItem
-        id={id}
+        node={root}
         parentNodeId={parentNodeId}
-        content={nodeData.keyword}
-        depth={nodeData.depth}
         handleAccordion={handleAccordion}
         open={open}
         openAccordion={openAccordion}
       />
       {open &&
-        nodeData.children.map((childId) => {
-          return <NodeList key={childId} data={data} parentNodeId={id} id={childId} />;
+        root.children.map((childId) => {
+          return <NodeList key={childId} data={data} parentNodeId={root.id} root={data[childId]} />;
         })}
     </div>
   );

--- a/client/src/components/MainSection/ControlSection/ListView/index.tsx
+++ b/client/src/components/MainSection/ControlSection/ListView/index.tsx
@@ -6,9 +6,5 @@ export default function ListView() {
 
   if (!data) return <p>데이터가 없습니다. 새롭게 추가해주세요!</p>;
 
-  return (
-    <div>
-      <NodeList data={data} id={1} />
-    </div>
-  );
+  return <div>{Object.keys(data).length >= 1 && <NodeList data={data} id={1} />}</div>;
 }

--- a/client/src/components/MainSection/ControlSection/ListView/index.tsx
+++ b/client/src/components/MainSection/ControlSection/ListView/index.tsx
@@ -1,10 +1,11 @@
 import NodeList from "@/components/MainSection/ControlSection/ListView/NodeList";
 import { useNodeListContext } from "@/store/NodeListProvider";
+import { Node } from "@/types/Node";
 
 export default function ListView() {
   const { data } = useNodeListContext();
+  if (!Object.keys(data).length) return <p>새로운 브레인스토밍을 시작해보세요</p>;
+  const root: Node = data[Object.keys(data)[0]];
 
-  if (!data) return <p>데이터가 없습니다. 새롭게 추가해주세요!</p>;
-
-  return <div>{Object.keys(data).length >= 1 && <NodeList data={data} id={1} />}</div>;
+  return <div>{Object.keys(data).length >= 1 && <NodeList data={data} root={root} />}</div>;
 }

--- a/client/src/components/MindMapView/CanvasButtons.tsx
+++ b/client/src/components/MindMapView/CanvasButtons.tsx
@@ -1,0 +1,16 @@
+import { useNodeListContext } from "@/store/NodeListProvider";
+import { Button } from "@headlessui/react";
+
+export default function CanvasButtons({ handleReArrange }) {
+  const { overrideNodeData } = useNodeListContext();
+  return (
+    <div className="absolute right-0 top-[-50px] flex gap-3">
+      <Button className="rounded-lg bg-grayscale-600 px-4 py-2 text-sm font-bold" onClick={handleReArrange}>
+        캔버스 재정렬
+      </Button>
+      <Button className="rounded-lg bg-grayscale-600 px-4 py-2 text-sm font-bold" onClick={() => overrideNodeData({})}>
+        캔버스 비우기
+      </Button>
+    </div>
+  );
+}

--- a/client/src/components/MindMapView/CanvasButtons.tsx
+++ b/client/src/components/MindMapView/CanvasButtons.tsx
@@ -1,16 +1,36 @@
+import DeleteConfirmModal from "@/components/MindMapView/DeleteConfirmModal";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { Button } from "@headlessui/react";
+import { useState } from "react";
+import { createPortal } from "react-dom";
 
 export default function CanvasButtons({ handleReArrange }) {
   const { overrideNodeData } = useNodeListContext();
+  const [showDeleteConfirmModal, setShowDeleteConfirmModal] = useState(false);
+  const resetAllNode = () => {
+    overrideNodeData({});
+    setShowDeleteConfirmModal(false);
+  };
   return (
     <div className="absolute right-0 top-[-50px] flex gap-3">
       <Button className="rounded-lg bg-grayscale-600 px-4 py-2 text-sm font-bold" onClick={handleReArrange}>
         캔버스 재정렬
       </Button>
-      <Button className="rounded-lg bg-grayscale-600 px-4 py-2 text-sm font-bold" onClick={() => overrideNodeData({})}>
+      <Button
+        className="rounded-lg bg-grayscale-600 px-4 py-2 text-sm font-bold"
+        onClick={() => setShowDeleteConfirmModal(true)}
+      >
         캔버스 비우기
       </Button>
+      {showDeleteConfirmModal &&
+        createPortal(
+          <DeleteConfirmModal
+            open={showDeleteConfirmModal}
+            closeModal={() => setShowDeleteConfirmModal(false)}
+            onConfirm={resetAllNode}
+          />,
+          document.body,
+        )}
     </div>
   );
 }

--- a/client/src/components/MindMapView/DeleteConfirmModal.tsx
+++ b/client/src/components/MindMapView/DeleteConfirmModal.tsx
@@ -1,0 +1,25 @@
+import Modal from "@/components/common/Modal";
+import { Button } from "@headlessui/react";
+
+type DeleteConfirmModalProps = {
+  open: boolean;
+  closeModal: () => void;
+  onConfirm: () => void;
+};
+export default function DeleteConfirmModal({ open, closeModal, onConfirm }: DeleteConfirmModalProps) {
+  return (
+    <Modal open={open} closeModal={closeModal}>
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2">
+        <p className="text-black">모든 노드를 초기화할까요?</p>
+        <div className="flex w-full gap-4">
+          <Button className="w-1/2 rounded-md bg-red-500 py-1" onClick={onConfirm}>
+            초기화할게요
+          </Button>
+          <Button className="w-1/2 rounded-md border border-grayscale-300 py-1 text-black" onClick={closeModal}>
+            안할래요
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/client/src/components/MindMapView/NoNodeInform.tsx
+++ b/client/src/components/MindMapView/NoNodeInform.tsx
@@ -1,0 +1,18 @@
+import { showNewNode } from "@/konva_mindmap/events/addNode";
+import { useNodeListContext } from "@/store/NodeListProvider";
+import { Button } from "@headlessui/react";
+
+export default function NoNodeInform() {
+  const { data, selectedNode, overrideNodeData } = useNodeListContext();
+  return (
+    <div className="absolute left-0 top-0 z-20 flex h-full w-full flex-col items-center justify-center bg-black bg-opacity-30">
+      <p className="mb-5 text-white">브레인스토밍을 시작해보세요.</p>
+      <Button
+        className="rounded-lg bg-bm-blue px-6 py-2"
+        onClick={() => showNewNode(data, selectedNode, overrideNodeData)}
+      >
+        시작하기
+      </Button>
+    </div>
+  );
+}

--- a/client/src/components/MindMapView/ToolMenu.tsx
+++ b/client/src/components/MindMapView/ToolMenu.tsx
@@ -5,7 +5,7 @@ import deleteIcon from "@/assets/trash.png";
 import { Button } from "@headlessui/react";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { StageDimension } from "@/konva_mindmap/types/dimension";
-import { addNode } from "@/konva_mindmap/events/addNode";
+import { addNode, showNewNode } from "@/konva_mindmap/events/addNode";
 import { deleteNode } from "@/konva_mindmap/events/deleteNode";
 import { useRef } from "react";
 
@@ -30,12 +30,14 @@ export default function ToolMenu({ dimensions, zoomIn, zoomOut }: ToolMenuProps)
 
   function handleAddButton() {
     saveHistory(JSON.stringify(data));
-    addNode(data, selectedNode, overrideNodeData);
+    showNewNode(data, selectedNode, overrideNodeData);
+    // addNode(data, selectedNode, overrideNodeData);
   }
   function handleDeleteButton() {
     saveHistory(JSON.stringify(data));
     deleteNode(JSON.stringify(data), selectedNode.nodeId, overrideNodeData);
     selectNode({ nodeId: 0, parentNodeId: 0 });
+    saveHistory(JSON.stringify(data));
   }
 
   return (

--- a/client/src/constants/color.ts
+++ b/client/src/constants/color.ts
@@ -1,0 +1,1 @@
+export const colors = ["skyblue", "lightgreen", "lightcoral"];

--- a/client/src/hooks/useHistoryState.ts
+++ b/client/src/hooks/useHistoryState.ts
@@ -31,5 +31,5 @@ export default function useHistoryState<T>(data: string) {
     [history, pointer],
   );
 
-  return { saveHistory, undo, redo };
+  return { saveHistory, undo, redo, history };
 }

--- a/client/src/hooks/useNodeActions.ts
+++ b/client/src/hooks/useNodeActions.ts
@@ -1,11 +1,14 @@
 import { useNodeListContext } from "@/store/NodeListProvider";
-import { ChangeEvent, KeyboardEvent, useState } from "react";
+import { ChangeEvent, KeyboardEvent, useEffect, useState } from "react";
 
 export default function useNodeActions(id: number, content: string) {
   const [hover, setHover] = useState<boolean>(false);
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [keyword, setKeyword] = useState(content);
   const { data, updateNode, saveHistory } = useNodeListContext();
+  useEffect(() => {
+    setKeyword(content);
+  }, [data]);
 
   const originalContent = content;
 

--- a/client/src/konva_mindmap/components/DrawMindMap.tsx
+++ b/client/src/konva_mindmap/components/DrawMindMap.tsx
@@ -1,6 +1,7 @@
 import MindMapNode from "@/konva_mindmap/components/MindMapNode";
 import ConnectedLine from "@/konva_mindmap/components/ConnectedLine";
 import { Node, NodeData } from "@/types/Node";
+import React from "react";
 
 type MindMapProps = {
   data: NodeData;
@@ -15,15 +16,15 @@ export default function DrawMindMap({ data, root, depth = 0, parentNode }: MindM
     <>
       <MindMapNode data={data} depth={depth} parentNode={parentNode} node={root} />
       {root.children?.map((childNode, index) => (
-        <>
+        <React.Fragment key={index}>
           <ConnectedLine
             from={root.location}
             to={data[childNode].location}
             fromRadius={70 - (depth + 1) * 10}
             toRadius={60 - (depth + 1) * 10}
           />
-          <DrawMindMap data={data} key={index} root={data[childNode]} depth={depth + 1} parentNode={root} />
-        </>
+          <DrawMindMap data={data} root={data[childNode]} depth={depth + 1} parentNode={root} />
+        </React.Fragment>
       ))}
     </>
   );

--- a/client/src/konva_mindmap/components/EditableText.tsx
+++ b/client/src/konva_mindmap/components/EditableText.tsx
@@ -24,23 +24,23 @@ export default function EditableText({
   width,
 }: EditableTextProps) {
   const originalContent = text;
-  const [content, setContent] = useState(originalContent);
+  const [keyword, setKeyword] = useState(originalContent);
   const { data, updateNode, saveHistory } = useNodeListContext();
 
   useEffect(() => {
-    setContent(text);
+    setKeyword(text);
   }, [text]);
 
   function handleTextChange(e: React.ChangeEvent<HTMLInputElement>) {
-    setContent(e.target.value);
+    setKeyword(e.target.value);
   }
 
   function saveContent() {
-    if (content.trim()) {
+    if (keyword.trim()) {
       saveHistory(JSON.stringify(data));
-      updateNode(id, { ...data[id], keyword: content });
+      updateNode(id, { keyword: keyword });
     } else {
-      setContent(originalContent);
+      setKeyword(originalContent);
     }
     setIsEditing(false);
   }
@@ -57,7 +57,7 @@ export default function EditableText({
     <>
       {isEditing ? (
         <EditableTextInput
-          value={content}
+          value={keyword}
           onChange={handleTextChange}
           onKeyDown={handleKeyDown}
           onBlur={handleBlur}
@@ -67,7 +67,7 @@ export default function EditableText({
         />
       ) : (
         <Text
-          text={content}
+          text={keyword}
           fill="black"
           wrap="word"
           align="center"

--- a/client/src/konva_mindmap/components/MindMapNode.tsx
+++ b/client/src/konva_mindmap/components/MindMapNode.tsx
@@ -1,19 +1,11 @@
 import EditableText from "@/konva_mindmap/components/EditableText";
-import { Node, NodeData } from "@/types/Node";
+import { NodeProps } from "@/types/Node";
 import { Circle, Group } from "react-konva";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { useState } from "react";
 import { checkFollowing, reconcileOffsets, resetSavedOffsets, saveOffsets } from "@/konva_mindmap/utils/following";
 import NewNode from "@/konva_mindmap/components/NewNode";
-
-export type NodeProps = {
-  data: NodeData;
-  parentNode?: Node;
-  node: Node;
-  depth: number;
-};
-
-export const colors = ["skyblue", "lightgreen", "lightcoral"];
+import { colors } from "@/constants/color";
 
 export default function MindMapNode({ data, parentNode, node, depth }: NodeProps) {
   if (node.newNode) return <NewNode data={data} parentNode={parentNode} node={node} depth={depth} />;

--- a/client/src/konva_mindmap/components/MindMapNode.tsx
+++ b/client/src/konva_mindmap/components/MindMapNode.tsx
@@ -4,7 +4,7 @@ import { Circle, Group } from "react-konva";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { useState } from "react";
 import { checkFollowing, reconcileOffsets, resetSavedOffsets, saveOffsets } from "@/konva_mindmap/utils/following";
-import NewNode from "@/konva_mindmap/components/newNode";
+import NewNode from "@/konva_mindmap/components/NewNode";
 
 export type NodeProps = {
   data: NodeData;

--- a/client/src/konva_mindmap/components/NewNode.tsx
+++ b/client/src/konva_mindmap/components/NewNode.tsx
@@ -1,11 +1,12 @@
+import { colors } from "@/constants/color";
 import EditableTextInput from "@/konva_mindmap/components/EditableTextInput";
-import { colors, NodeProps } from "@/konva_mindmap/components/MindMapNode";
 import { addNode } from "@/konva_mindmap/events/addNode";
 import { useNodeListContext } from "@/store/NodeListProvider";
+import { NodeProps } from "@/types/Node";
 import { useEffect, useState } from "react";
 import { Circle, Group } from "react-konva";
 
-export default function NewNode({ data, parentNode, node, depth }: NodeProps) {
+export default function NewNode({ data, node, depth }: NodeProps) {
   const { saveHistory, selectedNode, updateNode } = useNodeListContext();
   const [keyword, setKeyword] = useState("제목없음");
   useEffect(() => {

--- a/client/src/konva_mindmap/components/NewNode.tsx
+++ b/client/src/konva_mindmap/components/NewNode.tsx
@@ -1,0 +1,57 @@
+import EditableTextInput from "@/konva_mindmap/components/EditableTextInput";
+import { colors, NodeProps } from "@/konva_mindmap/components/MindMapNode";
+import { addNode } from "@/konva_mindmap/events/addNode";
+import { SelectedNode } from "@/konva_mindmap/types/Node";
+import { useNodeListContext } from "@/store/NodeListProvider";
+import { useEffect, useState } from "react";
+import { Circle, Group } from "react-konva";
+
+export default function NewNode({ data, parentNode, node, depth }: NodeProps) {
+  const { saveHistory, selectedNode, updateNode } = useNodeListContext();
+  const [keyword, setKeyword] = useState("제목없음");
+  console.log(node);
+  useEffect(() => {
+    setKeyword(keyword);
+  }, [keyword]);
+
+  function handleTextChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setKeyword(e.target.value);
+  }
+
+  function saveContent() {
+    if (keyword.trim()) {
+      saveHistory(JSON.stringify(data));
+      addNode(keyword, node.id, updateNode);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") saveContent();
+  }
+
+  function handleBlur() {
+    saveContent();
+  }
+
+  return (
+    <Group name="newNode" id={node.id.toString()} x={node.location.x} y={node.location.y}>
+      <Circle
+        fill={selectedNode?.nodeId === node.id ? "orange" : colors[depth - 1]}
+        width={100}
+        height={100}
+        strokeWidth={3}
+        radius={60 - depth * 10}
+        shadowBlur={5}
+      />
+      <EditableTextInput
+        value={keyword}
+        offsetX={70 - depth * 10}
+        offsetY={8 * depth - 60}
+        width={140 - depth * 20}
+        onBlur={handleBlur}
+        onChange={handleTextChange}
+        onKeyDown={handleKeyDown}
+      />
+    </Group>
+  );
+}

--- a/client/src/konva_mindmap/components/NewNode.tsx
+++ b/client/src/konva_mindmap/components/NewNode.tsx
@@ -1,7 +1,6 @@
 import EditableTextInput from "@/konva_mindmap/components/EditableTextInput";
 import { colors, NodeProps } from "@/konva_mindmap/components/MindMapNode";
 import { addNode } from "@/konva_mindmap/events/addNode";
-import { SelectedNode } from "@/konva_mindmap/types/Node";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { useEffect, useState } from "react";
 import { Circle, Group } from "react-konva";
@@ -9,7 +8,6 @@ import { Circle, Group } from "react-konva";
 export default function NewNode({ data, parentNode, node, depth }: NodeProps) {
   const { saveHistory, selectedNode, updateNode } = useNodeListContext();
   const [keyword, setKeyword] = useState("제목없음");
-  console.log(node);
   useEffect(() => {
     setKeyword(keyword);
   }, [keyword]);

--- a/client/src/konva_mindmap/events/addNode.ts
+++ b/client/src/konva_mindmap/events/addNode.ts
@@ -1,12 +1,38 @@
 import { unitVector } from "@/konva_mindmap/utils/vector";
 import { Node, NodeData, SelectedNode } from "@/types/Node";
 
-export function addNode(
+//newNode 플래그를 바꿔 실제 노드들과 상호작용할 수 있는 노드로 변환
+export function addNode(keyword: string, newNodeId: number, updateNode: (id: number, node: Partial<Node>) => void) {
+  updateNode(newNodeId, {
+    keyword: keyword,
+    newNode: false,
+  });
+}
+
+//바로 편집창이 On되어 있는 노드를 추가하는 함수
+export function showNewNode(
   data: NodeData,
   selectedNode: SelectedNode,
   overrideNodeData: React.Dispatch<React.SetStateAction<NodeData>>,
 ) {
-  if (!selectedNode || data[selectedNode.nodeId].depth === 3) return;
+  // 아무 노드도 없을 때는 임의로 id 생성해서 현재는 넣음
+  if (!Object.keys(data).length) {
+    overrideNodeData({
+      [1]: {
+        id: 1,
+        keyword: "제목 없음",
+        depth: 1,
+        location: {
+          x: 0,
+          y: 0,
+        },
+        children: [],
+        newNode: true,
+      },
+    });
+    return;
+  }
+  if (!selectedNode.nodeId || data[selectedNode.nodeId].depth === 3) return;
 
   const newNodeId = parseInt(Object.keys(data)[Object.keys(data).length - 1]) + 1;
   if (selectedNode.parentNodeId) {
@@ -23,6 +49,7 @@ export function addNode(
         depth: data[selectedNode.nodeId].depth + 1,
         location: getNewNodePosition(data[selectedNode.nodeId].children, data, data[selectedNode.nodeId]),
         children: [],
+        newNode: true,
       },
     }));
   }
@@ -35,10 +62,11 @@ export function addNode(
     },
     [newNodeId]: {
       id: newNodeId,
-      keyword: "제목없음",
+      keyword: "제목 없음",
       depth: data[selectedNode.nodeId].depth + 1,
       location: getNewNodePosition(data[selectedNode.nodeId].children, data, data[selectedNode.nodeId]),
       children: [],
+      newNode: true,
     },
   }));
   return newNodeId;

--- a/client/src/konva_mindmap/events/deleteNode.ts
+++ b/client/src/konva_mindmap/events/deleteNode.ts
@@ -1,6 +1,6 @@
 import { Node, NodeData } from "@/types/Node";
 
-export function deleteNode(data: string, selectedNodeId: number, update) {
+export function deleteNode(data: string, selectedNodeId: number, overrideNodeData) {
   if (!selectedNodeId) return;
   const newNodeData: NodeData = JSON.parse(data);
 
@@ -22,5 +22,5 @@ export function deleteNode(data: string, selectedNodeId: number, update) {
   }
 
   deleteNodeAndChildren(selectedNodeId);
-  update(newNodeData);
+  overrideNodeData(newNodeData);
 }

--- a/client/src/konva_mindmap/events/deleteNode.ts
+++ b/client/src/konva_mindmap/events/deleteNode.ts
@@ -2,19 +2,25 @@ import { Node, NodeData } from "@/types/Node";
 
 export function deleteNode(data: string, selectedNodeId: number, update) {
   if (!selectedNodeId) return;
-  const nodeData: NodeData = JSON.parse(data);
+  const newNodeData: NodeData = JSON.parse(data);
 
-  // 객체를 복사하여 불변성 유지
-  const targetData = nodeData[selectedNodeId];
+  function deleteNodeAndChildren(nodeId: number) {
+    const node = newNodeData[nodeId];
+    if (node.children) {
+      [...node.children].forEach((childId) => {
+        deleteNodeAndChildren(childId);
+      });
+    }
 
-  Object.values(nodeData).forEach((node: Node) => {
-    node.children = node.children.filter((childId) => childId !== selectedNodeId);
-  });
+    Object.values(newNodeData).forEach((node) => {
+      if (node.children) {
+        node.children = node.children.filter((id) => id !== nodeId);
+      }
+    });
 
-  targetData.children?.forEach((childId) => {
-    deleteNode(data, childId, update);
-  });
+    delete newNodeData[nodeId];
+  }
 
-  delete nodeData[selectedNodeId];
-  update(nodeData);
+  deleteNodeAndChildren(selectedNodeId);
+  update(newNodeData);
 }

--- a/client/src/konva_mindmap/events/ratioSizing.ts
+++ b/client/src/konva_mindmap/events/ratioSizing.ts
@@ -5,7 +5,6 @@ export function ratioSizing(e, dimensions, setDimensions) {
   const stage = e.target.getStage();
   const oldScale = stage.attrs.scaleX;
   const pointer = stage.getPointerPosition();
-  console.log(oldScale, pointer, stage.x(), stage.y());
   const mousePointTo = {
     // 포인터가 가르키는 x,y좌표를 기존 확대비율로 나눈 것에 stage의 x좌표에 기존 확대비율로 나눈 값을 뻄
     x: pointer.x / oldScale - stage.x() / oldScale,

--- a/client/src/konva_mindmap/hooks/useCollisionDetection.ts
+++ b/client/src/konva_mindmap/hooks/useCollisionDetection.ts
@@ -1,0 +1,43 @@
+import { useCallback, useRef, useEffect } from "react";
+import Konva from "konva";
+import { isCollided, moveOnCollision } from "@/konva_mindmap/utils/collision";
+import { Node, NodeData } from "@/types/Node";
+
+export function useCollisionDetection(nodeData: NodeData, updateNode: (id: number, updates: Partial<Node>) => void) {
+  const layer = useRef<Konva.Layer>(null);
+
+  const handleCollision = useCallback(
+    (base, target) => {
+      const newTargetPosition = moveOnCollision(target, base);
+
+      updateNode(target.attrs.id, { location: newTargetPosition });
+    },
+    [nodeData, updateNode],
+  );
+
+  const detectCollisions = useCallback(
+    (layer: Konva.Layer) => {
+      const nodes = layer.children.filter((child) => child.attrs.name === "node");
+      nodes.forEach((base) => {
+        nodes.forEach((target) => {
+          if (base !== target) {
+            if (isCollided(base.getClientRect(), target.getClientRect())) {
+              handleCollision(base, target);
+            }
+          }
+        });
+      });
+    },
+    [handleCollision],
+  );
+
+  useEffect(() => {
+    if (layer.current) {
+      requestAnimationFrame(() => {
+        detectCollisions(layer.current);
+      });
+    }
+  }, [nodeData, layer, detectCollisions]);
+
+  return layer;
+}

--- a/client/src/konva_mindmap/hooks/useDimension.ts
+++ b/client/src/konva_mindmap/hooks/useDimension.ts
@@ -52,14 +52,14 @@ export default function useDimension(data) {
   function zoomIn() {
     setDimensions((prevDimensions) => ({
       ...prevDimensions,
-      scale: prevDimensions.scale + 0.01,
+      scale: prevDimensions.scale + 0.05,
     }));
   }
 
   function zoomOut() {
     setDimensions((prevDimensions) => ({
       ...prevDimensions,
-      scale: prevDimensions.scale - 0.01,
+      scale: prevDimensions.scale - 0.05 < 0.05 ? 0.05 : prevDimensions.scale - 0.05,
     }));
   }
 

--- a/client/src/konva_mindmap/utils/collision.ts
+++ b/client/src/konva_mindmap/utils/collision.ts
@@ -1,31 +1,7 @@
 import Konva from "konva";
 import { Shape } from "konva/lib/Shape";
 
-export function checkCollision(layer: React.MutableRefObject<Konva.Layer>, update) {
-  const children = layer.current.children;
-  for (let i = 0; i < children.length; i++) {
-    const base = children[i];
-    if (base.attrs.name !== "node") continue;
-    for (let j = 0; j < children.length; j++) {
-      const target = children[j];
-      if (target.attrs.name !== "node") continue;
-      if (isCollided(base, target)) {
-        const newPosition = moveOnCollision(target, base);
-        update(parseInt(target.attrs.id), { location: newPosition });
-      }
-    }
-  }
-}
-
-export function isCollided(
-  node: Konva.Group | Shape<Konva.GroupConfig>,
-  target: Konva.Group | Shape<Konva.GroupConfig>,
-) {
-  if (node === target) return false;
-  return haveIntersection(node.getClientRect(), target.getClientRect());
-}
-
-export function haveIntersection(r1: Konva.RectConfig, r2: Konva.RectConfig) {
+export function isCollided(r1: Konva.RectConfig, r2: Konva.RectConfig) {
   return !(r2.x > r1.x + r1.width || r2.x + r2.width < r1.x || r2.y > r1.y + r1.height || r2.y + r2.height < r1.y);
 }
 
@@ -35,6 +11,13 @@ export function moveOnCollision(
 ) {
   const dx = targetNode.attrs.x - draggedNode.attrs.x;
   const dy = targetNode.attrs.y - draggedNode.attrs.y;
+  if (Math.sqrt(dx * dx + dy * dy) === 0) {
+    return {
+      x: targetNode.attrs.x + Math.random() * 20,
+      y: targetNode.attrs.y,
+    };
+  }
+
   const angle = Math.atan2(dy, dx);
 
   const minDistance = 10;

--- a/client/src/konva_mindmap/utils/download.ts
+++ b/client/src/konva_mindmap/utils/download.ts
@@ -1,0 +1,8 @@
+export function downloadURI(uri, name) {
+  let link = document.createElement("a");
+  link.download = name;
+  link.href = uri;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}

--- a/client/src/konva_mindmap/utils/following.ts
+++ b/client/src/konva_mindmap/utils/following.ts
@@ -1,0 +1,111 @@
+import { Location } from "@/konva_mindmap/types/location";
+import { Node, NodeData } from "@/types/Node";
+
+class OffsetManager {
+  private savedOffsets: Map<number, Location> = new Map();
+
+  saveOffset(nodeId: number, offset: Location): void {
+    this.savedOffsets.set(nodeId, offset);
+  }
+
+  getOffset(nodeId: number): Location | undefined {
+    return this.savedOffsets.get(nodeId);
+  }
+
+  reset(): void {
+    this.savedOffsets.clear();
+  }
+}
+
+const offsetManager = new OffsetManager();
+const maxDistance = 400;
+
+export function checkFollowing(
+  data: NodeData,
+  root: Node,
+  updateNode: (id: number, updates: Partial<Node>) => void,
+): void {
+  if (!root.children || root.children.length === 0) return;
+
+  root.children.forEach((childId) => {
+    const childNode = data[childId];
+    if (!childNode) return;
+
+    adjustNodePositions(root, childNode, updateNode);
+    checkFollowing(data, childNode, updateNode);
+  });
+}
+
+export function saveOffsets(data: NodeData, root: Node): void {
+  if (!root.children || !root.location) return;
+
+  root.children.forEach((childNodeId) => {
+    const childNode = data[childNodeId];
+    if (!childNode || !childNode.location) return;
+
+    const offsets: Location = {
+      x: childNode.location.x - root.location.x,
+      y: childNode.location.y - root.location.y,
+    };
+
+    offsetManager.saveOffset(childNodeId, offsets);
+
+    // 재귀적으로 자식 노드들의 offset 저장
+    saveOffsets(data, childNode);
+  });
+}
+
+export function resetSavedOffsets(): void {
+  offsetManager.reset();
+}
+
+export function reconcileOffsets(
+  data: NodeData,
+  root: Node,
+  updateNode: (id: number, updates: Partial<Node>) => void,
+  updatedParentLocation?: Location,
+): void {
+  if (!root.children || !root.location) return;
+
+  root.children.forEach((childNodeId) => {
+    const childNode = data[childNodeId];
+    if (!childNode) return;
+
+    const offset = offsetManager.getOffset(childNodeId);
+    if (!offset) return;
+
+    const newLocation: Location = {
+      x: updatedParentLocation ? updatedParentLocation.x + offset.x : root.location.x + offset.x,
+      y: updatedParentLocation ? updatedParentLocation.y + offset.y : root.location.y + offset.y,
+    };
+
+    updateNode(childNode.id, { location: newLocation });
+
+    // 재귀적으로 자식 노드들의 위치 조정
+    reconcileOffsets(data, childNode, updateNode, newLocation);
+  });
+}
+
+export function adjustNodePositions(
+  parentNode: Node,
+  targetNode: Node,
+  updateNode: (id: number, updates: Partial<Node>) => void,
+): void {
+  if (!parentNode.location || !targetNode.location) return;
+
+  const dx = targetNode.location.x - parentNode.location.x;
+  const dy = targetNode.location.y - parentNode.location.y;
+  const distance = Math.sqrt(dx * dx + dy * dy);
+
+  if (distance > maxDistance) {
+    const directionX = dx / distance;
+    const directionY = dy / distance;
+
+    const newLocation: Location = {
+      x: parentNode.location.x + directionX * maxDistance,
+      y: parentNode.location.y + directionY * maxDistance,
+    };
+
+    updateNode(targetNode.id, { location: newLocation });
+  }
+}

--- a/client/src/store/NodeListProvider.tsx
+++ b/client/src/store/NodeListProvider.tsx
@@ -6,14 +6,13 @@ import { createContext, ReactNode, useContext, useEffect, useState } from "react
 export type NodeListContextType = {
   data: NodeData | null;
   selectedNode: { nodeId: number; parentNodeId: number } | null;
-  updateNode: (id: number, node: Node) => void;
+  history: string[];
+  updateNode: (id: number, node: Partial<Node>) => void;
   overrideNodeData: (node: NodeData | ((newData: NodeData) => void)) => void;
   saveHistory: (newState: string) => void;
   undoData: () => void;
   redoData: () => void;
   selectNode: ({ nodeId, parentNodeId }: SelectedNode) => void;
-  focusNodeId: number | null;
-  updateFocusNodeId: (newId: number | null) => void;
 };
 
 const nodeData = {
@@ -207,10 +206,9 @@ const dummy = initializeNodePosition(nodeData);
 export default function NodeListProvider({ children }: { children: ReactNode }) {
   const [data, setData] = useState({ ...dummy });
   const [selectedNode, setSelectedNode] = useState({ nodeId: 0, parentNodeId: 0 });
-  const { saveHistory, undo, redo } = useHistoryState<NodeData>(JSON.stringify(data));
-  const [focusNodeId, setFocusNodeId] = useState(null);
+  const { saveHistory, undo, redo, history } = useHistoryState<NodeData>(JSON.stringify(data));
 
-  function updateNode(id: number, updatedNode: Node) {
+  function updateNode(id: number, updatedNode: Partial<Node>) {
     setData((prevData) => ({
       ...prevData,
       [id]: { ...prevData[id], ...updatedNode },
@@ -240,10 +238,6 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
     });
   }
 
-  function updateFocusNodeId(newId: number | null) {
-    setFocusNodeId(newId);
-  }
-
   return (
     <NodeListContext.Provider
       value={{
@@ -255,8 +249,7 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
         saveHistory,
         selectNode,
         selectedNode,
-        focusNodeId,
-        updateFocusNodeId,
+        history,
       }}
     >
       {children}

--- a/client/src/store/useStageStore.ts
+++ b/client/src/store/useStageStore.ts
@@ -1,0 +1,15 @@
+import Konva from "konva";
+import { RefObject } from "react";
+import { create } from "zustand";
+
+interface StageStore {
+  stage: null | RefObject<Konva.Stage>;
+  registerStageRef: (stage: RefObject<Konva.Stage>) => void;
+}
+export const useStageStore = create<StageStore>((set) => ({
+  stage: null,
+  registerStageRef: (stage) =>
+    set({
+      stage: stage,
+    }),
+}));

--- a/client/src/types/Node.ts
+++ b/client/src/types/Node.ts
@@ -6,6 +6,7 @@ export type Node = {
   depth: number;
   location: Location;
   children: number[] | [];
+  newNode?: boolean;
 };
 
 export type NodeData = Record<number, Node>;

--- a/client/src/types/Node.ts
+++ b/client/src/types/Node.ts
@@ -15,3 +15,10 @@ export type SelectedNode = {
   nodeId: number;
   parentNodeId: number;
 };
+
+export type NodeProps = {
+  data: NodeData;
+  parentNode?: Node;
+  node: Node;
+  depth: number;
+};


### PR DESCRIPTION
## 작업 내용
### feature
- 새로운 노드를 추가할 때 생길 노드를 따로 구분하여 추가되도록 하였습니다.
  - showNewNode를 통해 상태에 newNode property가 붙어있는 노드를 추가하고, 편집이 완료되면 addNode를 통해 노드의 플래그를 바꿔주어 실제 다른 노드를과 상호작용하는 노드로 바꿀 수 있습니다.
- 캔버스 비우기를 눌렀을 때, 확인 모달이 뜨고 '초기화할게요'버튼을 누르면 캔버스가 초기화되도록 변경했습니다.
  - 캔버스 모달의 경우 react-portal을 사용해서 body 태그에서 렌더링될 수 있도록 구현했습니다.
- 하나의 노드를 끌어당길 때, 일정 길이 이상 나가게 된다면 부모가 움직이는 방향에 따라 자식 노드가 따라갈 수 있도록 로직을 구현했습니다.
  - 각각의 자식 노드들은 드래그가 시작될 때, 부모 노드에 대한 자식 노드의 offset을 map 자료구조에 저장하고, 드래그가 끝난 후에는 다시 해당 map에서 각 노드들의 상대적 위치 정보를 가져와 업데이트 할 수 있도록 했습니다.

[노드가 따라가게 하기 기술공유 노션 링크](https://luxurious-share-af6.notion.site/1417725fa9ac8060944ec3769d9056a8?pvs=4)

### fix
- addNode했을 때의 리스트 뷰 로직이 제가 리팩토링했던 부분과 달라 협의 후 조정되었습니다.

### chore
- node 타입의 경로를 변경하면서 import문들의 경로 또한 변경했습니다.

### refactor
- 캔버스 재정렬 및 비우기 버튼 컴포넌트가 로직이 추가되면서 가독성이 떨어지는 문제가 생겨 mindmapView에서 분리할 필요가 있다 판단하여 컴포넌트 분리를 진행했습니다
- 더불어 마인드맵뷰에 붙어있던 collision detection 관련 로직 또한 커스텀 훅으로 분리하여 하나의 컴포넌트에서도 관심사 분리가 될 수 있도록 하였습니다
- 리스트 뷰에서 node의 prop들을 destructuring해서 넣어주던 컴포넌트를 node를 그대로 넘겨주는 방식으로 변경했습니다

## 논의하고 싶은 내용
- 리스트뷰와 캔버스 뷰에서 동시 편집을 지원하게 하기 위해서는 각각 관리하던 상태를 전역상태로 묶거나 context api를 다시 사용해야 할 것 같아요. 이대루 둬도 괜찮을지 이야기 한번 놔눠보면 좋을 것 같습니당
