### PR TITLE
[feature-3-7-fix-fe] 누락된 소켓 연결 시나리오 추가 및 이벤트 리스너 중복 부착으로 인한 history 문제 해결

### DIFF
--- a/client/src/components/Dashboard/GuestDashBoard.tsx
+++ b/client/src/components/Dashboard/GuestDashBoard.tsx
@@ -1,7 +1,7 @@
 import dashboardIcon from "@/assets/dashbordIcon.png";
 import plusIcon from "@/assets/plus.png";
 import LoginModal from "@/components/LoginModal";
-import { SocketSlice } from "@/store/SocketSlice";
+import { useSocketStore } from "@/store/useSocketStore";
 import { Button } from "@headlessui/react";
 import { useState } from "react";
 import { createPortal } from "react-dom";
@@ -11,7 +11,7 @@ export default function GuestDashBoard() {
   const [loginModal, setLoginModal] = useState(false);
 
   const navigate = useNavigate();
-  const { handleConnection } = SocketSlice();
+  const { handleConnection } = useSocketStore();
 
   return (
     <>

--- a/client/src/components/Dashboard/GuestDashBoard.tsx
+++ b/client/src/components/Dashboard/GuestDashBoard.tsx
@@ -1,8 +1,6 @@
-import { createMindmap } from "@/api/mindmap.api";
 import dashboardIcon from "@/assets/dashbordIcon.png";
 import plusIcon from "@/assets/plus.png";
 import LoginModal from "@/components/LoginModal";
-import useSection from "@/hooks/useSection";
 import { SocketSlice } from "@/store/SocketSlice";
 import { Button } from "@headlessui/react";
 import { useState } from "react";
@@ -11,20 +9,9 @@ import { useNavigate } from "react-router-dom";
 
 export default function GuestDashBoard() {
   const [loginModal, setLoginModal] = useState(false);
-  const { socket, connectSocket } = SocketSlice();
-  const navigate = useNavigate();
 
-  async function handleConnection() {
-    try {
-      if (socket) socket.disconnect();
-      const response = await createMindmap();
-      const newMindMapId = response.data;
-      connectSocket(newMindMapId);
-      navigate(`/mindmap/${newMindMapId}?mode=textupload`);
-    } catch (error) {
-      console.error(error);
-    }
-  }
+  const navigate = useNavigate();
+  const { handleConnection } = SocketSlice();
 
   return (
     <>
@@ -37,7 +24,7 @@ export default function GuestDashBoard() {
         <img className="w-[300px]" src={dashboardIcon} alt="대쉬보드 아이콘" />
         <Button
           className="group flex w-[300px] items-center justify-center gap-3 rounded-[10px] bg-grayscale-600 px-10 py-2 text-grayscale-200 hover:text-white"
-          onClick={handleConnection}
+          onClick={() => handleConnection(navigate, "textupload")}
         >
           <img className="w-6 group-hover:brightness-0 group-hover:invert" src={plusIcon} alt="추가하기 아이콘" />
           <p className="text-xl text-grayscale-200 group-hover:text-white">새로운 마인드맵 만들기</p>

--- a/client/src/components/MindMapCanvas/CanvasButtons.tsx
+++ b/client/src/components/MindMapCanvas/CanvasButtons.tsx
@@ -1,12 +1,12 @@
 import DeleteConfirmModal from "@/components/MindMapCanvas/DeleteConfirmModal";
 import { useNodeListContext } from "@/store/NodeListProvider";
-import { SocketSlice } from "@/store/SocketSlice";
+import { useSocketStore } from "@/store/useSocketStore";
 import { Button } from "@headlessui/react";
 import { useState } from "react";
 import { createPortal } from "react-dom";
 
 export default function CanvasButtons({ handleReArrange, showMinutes, handleShowMinutes }) {
-  const { handleSocketEvent } = SocketSlice();
+  const { handleSocketEvent } = useSocketStore();
   const { overrideNodeData } = useNodeListContext();
   const [showDeleteConfirmModal, setShowDeleteConfirmModal] = useState(false);
   const resetAllNode = () => {

--- a/client/src/components/MindMapCanvas/CanvasButtons.tsx
+++ b/client/src/components/MindMapCanvas/CanvasButtons.tsx
@@ -7,20 +7,17 @@ import { createPortal } from "react-dom";
 
 export default function CanvasButtons({ handleReArrange, showMinutes, handleShowMinutes }) {
   const { handleSocketEvent } = SocketSlice();
-  const { data, overrideNodeData } = useNodeListContext();
+  const { overrideNodeData } = useNodeListContext();
   const [showDeleteConfirmModal, setShowDeleteConfirmModal] = useState(false);
   const resetAllNode = () => {
     handleSocketEvent({
-      actionType: "deleteNode",
-      payload: { id: Object.keys(data) },
-      callback: () =>
-        handleSocketEvent({
-          actionType: "updateNode",
-          payload: {},
-        }),
+      actionType: "updateNode",
+      payload: {},
+      callback: () => {
+        overrideNodeData({});
+        setShowDeleteConfirmModal(false);
+      },
     });
-    overrideNodeData({});
-    setShowDeleteConfirmModal(false);
   };
   return (
     <div className="absolute right-0 top-[-50px] flex gap-3">

--- a/client/src/components/MindMapCanvas/ToolMenu.tsx
+++ b/client/src/components/MindMapCanvas/ToolMenu.tsx
@@ -31,13 +31,11 @@ export default function ToolMenu({ dimensions, zoomIn, zoomOut }: ToolMenuProps)
   function handleAddButton() {
     saveHistory(JSON.stringify(data));
     showNewNode(data, selectedNode, overrideNodeData);
-    // addNode(data, selectedNode, overrideNodeData);
   }
   function handleDeleteButton() {
     saveHistory(JSON.stringify(data));
     deleteNode(JSON.stringify(data), selectedNode.nodeId, overrideNodeData);
     selectNode({ nodeId: 0, parentNodeId: 0 });
-    saveHistory(JSON.stringify(data));
   }
 
   return (

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -12,6 +12,7 @@ import NoNodeInform from "@/components/MindMapCanvas/NoNodeInform";
 import CanvasButtons from "@/components/MindMapCanvas/CanvasButtons";
 import ShowShortCut from "./ShowShortCut";
 import { findRootNodeKey } from "@/konva_mindmap/utils/findRootNodeKey";
+import { SocketSlice } from "@/store/SocketSlice";
 
 export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
   const {
@@ -27,6 +28,7 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
   const registerLayer = useCollisionDetection(data, updateNode);
   const stageRef = useRef();
   const { registerStageRef } = useStageStore();
+  const handleSocketEvent = SocketSlice.getState().handleSocketEvent;
 
   const rootKey = findRootNodeKey(data);
 
@@ -39,9 +41,16 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
     y: redo,
   };
   function handleReArrange() {
-    const savedData = JSON.stringify(data);
-    saveHistory(savedData);
-    overrideNodeData(initializeNodePosition(JSON.parse(savedData)));
+    handleSocketEvent({
+      actionType: "updateNode",
+      payload: initializeNodePosition(data),
+      callback: (response) => {
+        if (response) {
+          saveHistory(JSON.stringify(data));
+          overrideNodeData(response);
+        }
+      },
+    });
   }
 
   useWindowKeyEventListener("keydown", (e) => {

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -12,7 +12,7 @@ import NoNodeInform from "@/components/MindMapCanvas/NoNodeInform";
 import CanvasButtons from "@/components/MindMapCanvas/CanvasButtons";
 import ShowShortCut from "./ShowShortCut";
 import { findRootNodeKey } from "@/konva_mindmap/utils/findRootNodeKey";
-import { SocketSlice } from "@/store/SocketSlice";
+import { useSocketStore } from "@/store/useSocketStore";
 
 export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
   const {
@@ -28,7 +28,7 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
   const registerLayer = useCollisionDetection(data, updateNode);
   const stageRef = useRef();
   const { registerStageRef } = useStageStore();
-  const handleSocketEvent = SocketSlice.getState().handleSocketEvent;
+  const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
 
   const rootKey = findRootNodeKey(data);
 

--- a/client/src/components/MindMapMainSection/index.tsx
+++ b/client/src/components/MindMapMainSection/index.tsx
@@ -2,7 +2,7 @@ import NotFound from "@/components/common/NotFound";
 import MindMapHeader from "@/components/MindMapHeader";
 import MindMapView from "@/components/MindMapMainSection/MindMapView";
 import useSection from "@/hooks/useSection";
-import { SocketSlice } from "@/store/SocketSlice";
+import { useSocketStore } from "@/store/useSocketStore";
 import { useEffect } from "react";
 import { useParams } from "react-router-dom";
 
@@ -15,7 +15,7 @@ const modeView = {
 export default function MindMapMainSection() {
   const mode = useSection().searchParams.get("mode") as keyof typeof modeView;
   const { mindMapId } = useParams<{ mindMapId: string }>();
-  const { connectSocket, disconnectSocket } = SocketSlice();
+  const { connectSocket, disconnectSocket } = useSocketStore();
 
   useEffect(() => {
     if (mindMapId) connectSocket(mindMapId);

--- a/client/src/components/Sidebar/Overview.tsx
+++ b/client/src/components/Sidebar/Overview.tsx
@@ -6,13 +6,17 @@ import textIcon from "@/assets/textFile.png";
 import OverviewButton from "@/components/Sidebar/OverviewButton";
 import useSection from "@/hooks/useSection";
 import { useNavigate } from "react-router-dom";
+import { SocketSlice } from "@/store/SocketSlice";
 
 export default function Overview() {
   const navigate = useNavigate();
   const { getmode, handleViewMode } = useSection();
+  const { socket, handleConnection } = SocketSlice();
+
   const navigateMindmap = (mode: "listview" | "voiceupload" | "textupload") => {
-    navigate("/mindmap");
-    handleViewMode(mode);
+    if (socket) {
+      handleViewMode(mode);
+    } else handleConnection(navigate, mode);
   };
   return (
     <div className="mt-14 flex flex-col text-base">

--- a/client/src/components/Sidebar/Overview.tsx
+++ b/client/src/components/Sidebar/Overview.tsx
@@ -6,12 +6,12 @@ import textIcon from "@/assets/textFile.png";
 import OverviewButton from "@/components/Sidebar/OverviewButton";
 import useSection from "@/hooks/useSection";
 import { useNavigate } from "react-router-dom";
-import { SocketSlice } from "@/store/SocketSlice";
+import { useSocketStore } from "@/store/useSocketStore";
 
 export default function Overview() {
   const navigate = useNavigate();
   const { getmode, handleViewMode } = useSection();
-  const { socket, handleConnection } = SocketSlice();
+  const { socket, handleConnection } = useSocketStore();
 
   const navigateMindmap = (mode: "listview" | "voiceupload" | "textupload") => {
     if (socket) {

--- a/client/src/hooks/useHistoryState.ts
+++ b/client/src/hooks/useHistoryState.ts
@@ -1,10 +1,10 @@
-import { SocketSlice } from "@/store/SocketSlice";
-import { useState, useCallback, useEffect } from "react";
+import { useSocketStore } from "@/store/useSocketStore";
+import { useState, useCallback } from "react";
 
 export default function useHistoryState<T>(data: string) {
   const [history, setHistory] = useState([data]);
   const [pointer, setPointer] = useState(0);
-  const handleSocketEvent = SocketSlice.getState().handleSocketEvent;
+  const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
 
   const saveHistory = useCallback(
     (data: string) => {

--- a/client/src/hooks/useHistoryState.ts
+++ b/client/src/hooks/useHistoryState.ts
@@ -1,5 +1,5 @@
 import { SocketSlice } from "@/store/SocketSlice";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 
 export default function useHistoryState<T>(data: string) {
   const [history, setHistory] = useState([data]);
@@ -10,6 +10,14 @@ export default function useHistoryState<T>(data: string) {
     (data: string) => {
       setHistory((prevHistory) => [...prevHistory.slice(0, pointer + 1), data]);
       setPointer((p) => p + 1);
+    },
+    [pointer],
+  );
+
+  const overrideHistory = useCallback(
+    (data: string) => {
+      setHistory([data]);
+      setPointer(0);
     },
     [pointer],
   );
@@ -48,5 +56,5 @@ export default function useHistoryState<T>(data: string) {
     [history, pointer],
   );
 
-  return { saveHistory, undo, redo, history };
+  return { saveHistory, overrideHistory, undo, redo, history };
 }

--- a/client/src/hooks/useHistoryState.ts
+++ b/client/src/hooks/useHistoryState.ts
@@ -24,7 +24,7 @@ export default function useHistoryState<T>(data: string) {
 
   const undo = useCallback(
     (setData) => {
-      if (!history[0] || pointer < 0) return;
+      if (!history[0] || pointer <= 0) return;
       const parsedData = JSON.parse(history[pointer - 1]);
       if (socket) {
         socket.emit("updateNode", parsedData);

--- a/client/src/konva_mindmap/components/EditableText.tsx
+++ b/client/src/konva_mindmap/components/EditableText.tsx
@@ -2,7 +2,7 @@ import { Text } from "react-konva";
 import { useEffect, useState } from "react";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import EditableTextInput from "@/konva_mindmap/components/EditableTextInput";
-import { SocketSlice } from "@/store/SocketSlice";
+import { useSocketStore } from "@/store/useSocketStore";
 
 interface EditableTextProps {
   id: number;
@@ -27,7 +27,7 @@ export default function EditableText({
   const originalContent = text;
   const [keyword, setKeyword] = useState(originalContent);
   const { data, updateNode, saveHistory } = useNodeListContext();
-  const handleSocketEvent = SocketSlice.getState().handleSocketEvent;
+  const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
 
   useEffect(() => {
     setKeyword(text);

--- a/client/src/konva_mindmap/components/EditableText.tsx
+++ b/client/src/konva_mindmap/components/EditableText.tsx
@@ -27,7 +27,7 @@ export default function EditableText({
   const originalContent = text;
   const [keyword, setKeyword] = useState(originalContent);
   const { data, updateNode, saveHistory } = useNodeListContext();
-  const socket = SocketSlice.getState().socket;
+  const handleSocketEvent = SocketSlice.getState().handleSocketEvent;
 
   useEffect(() => {
     setKeyword(text);
@@ -39,16 +39,14 @@ export default function EditableText({
 
   function saveContent() {
     if (keyword.trim()) {
-      if (socket) {
-        socket.off("updateNode");
-        socket.emit("updateNode", { ...data, [id]: { ...data[id], keyword: keyword } });
-        socket.on("updateNode", (response) => {
-          if (response) {
-            saveHistory(JSON.stringify(data));
-            updateNode(id, { keyword: keyword });
-          }
-        });
-      }
+      handleSocketEvent({
+        actionType: "updateNode",
+        payload: { ...data, [id]: { ...data[id], keyword: keyword } },
+        callback: () => {
+          saveHistory(JSON.stringify(data));
+          updateNode(id, { keyword: keyword });
+        },
+      });
     } else {
       setKeyword(originalContent);
     }

--- a/client/src/konva_mindmap/components/MindMapNode.tsx
+++ b/client/src/konva_mindmap/components/MindMapNode.tsx
@@ -12,7 +12,7 @@ export default function MindMapNode({ data, parentNode, node, depth }: NodeProps
   if (node.newNode) return <NewNode data={data} parentNode={parentNode} node={node} depth={depth} />;
   const { saveHistory, updateNode, selectNode, selectedNode } = useNodeListContext();
   const [isEditing, setIsEditing] = useState(false);
-  const socket = SocketSlice.getState().socket;
+  const handleSocketEvent = SocketSlice.getState().handleSocketEvent;
 
   function handleDoubleClick() {
     setIsEditing(true);
@@ -29,14 +29,13 @@ export default function MindMapNode({ data, parentNode, node, depth }: NodeProps
   function handleDragEnd() {
     const reconciledData = reconcileOffsets(data, node, updateNode);
     resetSavedOffsets();
-    if (socket) {
-      socket.emit("updateNode", reconciledData);
-      socket.on("updateNode", (response) => {
-        if (response) {
-          saveHistory(JSON.stringify(reconciledData));
-        }
-      });
-    }
+    handleSocketEvent({
+      actionType: "updateNode",
+      payload: reconciledData,
+      callback: () => {
+        saveHistory(JSON.stringify(reconciledData));
+      },
+    });
   }
 
   function handleClick() {

--- a/client/src/konva_mindmap/components/MindMapNode.tsx
+++ b/client/src/konva_mindmap/components/MindMapNode.tsx
@@ -3,7 +3,7 @@ import { NodeProps } from "@/types/Node";
 import { Circle, Group } from "react-konva";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { useState } from "react";
-import { SocketSlice } from "@/store/SocketSlice";
+import { useSocketStore } from "@/store/useSocketStore";
 import { checkFollowing, reconcileOffsets, resetSavedOffsets, saveOffsets } from "@/konva_mindmap/utils/following";
 import NewNode from "@/konva_mindmap/components/NewNode";
 import { colors } from "@/constants/color";
@@ -12,7 +12,7 @@ export default function MindMapNode({ data, parentNode, node, depth }: NodeProps
   if (node.newNode) return <NewNode data={data} parentNode={parentNode} node={node} depth={depth} />;
   const { saveHistory, updateNode, selectNode, selectedNode } = useNodeListContext();
   const [isEditing, setIsEditing] = useState(false);
-  const handleSocketEvent = SocketSlice.getState().handleSocketEvent;
+  const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
 
   function handleDoubleClick() {
     setIsEditing(true);

--- a/client/src/konva_mindmap/components/NewNode.tsx
+++ b/client/src/konva_mindmap/components/NewNode.tsx
@@ -2,7 +2,7 @@ import { colors } from "@/constants/color";
 import EditableTextInput from "@/konva_mindmap/components/EditableTextInput";
 import { addNode } from "@/konva_mindmap/events/addNode";
 import { useNodeListContext } from "@/store/NodeListProvider";
-import { SocketSlice } from "@/store/SocketSlice";
+import { useSocketStore } from "@/store/useSocketStore";
 import { NodeProps } from "@/types/Node";
 import { useEffect, useState } from "react";
 import { Circle, Group } from "react-konva";
@@ -14,7 +14,7 @@ export default function NewNode({ data, node, depth }: NodeProps) {
     setKeyword(keyword);
   }, [keyword]);
 
-  const handleSocketEvent = SocketSlice.getState().handleSocketEvent;
+  const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
 
   function handleTextChange(e: React.ChangeEvent<HTMLInputElement>) {
     setKeyword(e.target.value);

--- a/client/src/konva_mindmap/components/NewNode.tsx
+++ b/client/src/konva_mindmap/components/NewNode.tsx
@@ -14,7 +14,7 @@ export default function NewNode({ data, node, depth }: NodeProps) {
     setKeyword(keyword);
   }, [keyword]);
 
-  const socket = SocketSlice.getState().socket;
+  const handleSocketEvent = SocketSlice.getState().handleSocketEvent;
 
   function handleTextChange(e: React.ChangeEvent<HTMLInputElement>) {
     setKeyword(e.target.value);
@@ -22,16 +22,14 @@ export default function NewNode({ data, node, depth }: NodeProps) {
 
   function saveContent() {
     if (keyword.trim()) {
-      if (socket) {
-        socket.off("updateNode");
-        socket.emit("updateNode", { ...data, [node.id]: { ...data[node.id], keyword: keyword, newNode: false } });
-        socket.on("updateNode", (response) => {
-          if (response) {
-            saveHistory(JSON.stringify(data));
-            addNode(keyword, node.id, updateNode);
-          }
-        });
-      }
+      handleSocketEvent({
+        actionType: "updateNode",
+        payload: { ...data, [node.id]: { ...data[node.id], keyword: keyword, newNode: false } },
+        callback: () => {
+          saveHistory(JSON.stringify(data));
+          addNode(keyword, node.id, updateNode);
+        },
+      });
     }
   }
 

--- a/client/src/konva_mindmap/events/addNode.ts
+++ b/client/src/konva_mindmap/events/addNode.ts
@@ -1,5 +1,5 @@
 import { unitVector } from "@/konva_mindmap/utils/vector";
-import { SocketSlice } from "@/store/SocketSlice";
+import { useSocketStore } from "@/store/useSocketStore";
 import { Node, NodeData, SelectedNode } from "@/types/Node";
 
 //newNode 플래그를 바꿔 실제 노드들과 상호작용할 수 있는 노드로 변환
@@ -16,7 +16,7 @@ export function showNewNode(
   selectedNode: SelectedNode,
   overrideNodeData: React.Dispatch<React.SetStateAction<NodeData>>,
 ) {
-  const handleSocketEvent = SocketSlice.getState().handleSocketEvent;
+  const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
   // 아무 노드도 없을 때는 임의로 id 생성해서 현재는 넣음
   if (!Object.keys(data).length) {
     const newNode = {

--- a/client/src/konva_mindmap/events/addNode.ts
+++ b/client/src/konva_mindmap/events/addNode.ts
@@ -16,7 +16,7 @@ export function showNewNode(
   selectedNode: SelectedNode,
   overrideNodeData: React.Dispatch<React.SetStateAction<NodeData>>,
 ) {
-  const socket = SocketSlice.getState().socket;
+  const handleSocketEvent = SocketSlice.getState().handleSocketEvent;
   // 아무 노드도 없을 때는 임의로 id 생성해서 현재는 넣음
   if (!Object.keys(data).length) {
     const newNode = {
@@ -32,17 +32,22 @@ export function showNewNode(
         newNode: true,
       },
     };
-    if (socket) {
-      socket.off("createNode");
-      socket.emit("createNode", newNode[1]);
-      socket.on("createNode", (response) => {
+    handleSocketEvent({
+      actionType: "createNode",
+      payload: newNode[1],
+      callback: (response) => {
         if (response) {
-          const updatedData = { [response.id]: { ...newNode[1], id: response.id } };
+          const updatedData = {
+            [response.id]: { ...newNode[1], id: response.id },
+          };
           overrideNodeData(updatedData);
-          socket.emit("updateNode", updatedData);
+          handleSocketEvent({
+            actionType: "updateNode",
+            payload: updatedData,
+          });
         }
-      });
-    }
+      },
+    });
     return;
   }
   if (!selectedNode.nodeId || data[selectedNode.nodeId].depth === 3) return;
@@ -58,14 +63,10 @@ export function showNewNode(
     newNode: true,
   };
 
-  if (socket) {
-    // 기존에 있던 리스너 제거
-    socket.off("createNode");
-    // 서버에 새로운 노드 생성 요청
-    socket.emit("createNode", { ...newNode, parentId: selectedNode.nodeId });
-
-    // 서버에서 응답이 오면 updateNode 이벤트 발생, 전체 데이터 전송
-    socket.on("createNode", (response) => {
+  handleSocketEvent({
+    actionType: "createNode",
+    payload: { ...newNode, parentId: selectedNode.nodeId },
+    callback: (response) => {
       if (response) {
         const updatedData = {
           ...data,
@@ -76,10 +77,13 @@ export function showNewNode(
           [response.id]: { ...newNode, id: response.id },
         };
         overrideNodeData(updatedData);
-        socket.emit("updateNode", updatedData);
+        handleSocketEvent({
+          actionType: "updateNode",
+          payload: updatedData,
+        });
       }
-    });
-  }
+    },
+  });
   return newNodeId;
 }
 

--- a/client/src/konva_mindmap/events/deleteNode.ts
+++ b/client/src/konva_mindmap/events/deleteNode.ts
@@ -1,4 +1,4 @@
-import { SocketSlice } from "@/store/SocketSlice";
+import { useSocketStore } from "@/store/useSocketStore";
 import { NodeData } from "@/types/Node";
 
 export function deleteNode(data: string, selectedNodeId: number, overrideNodeData) {
@@ -23,7 +23,7 @@ export function deleteNode(data: string, selectedNodeId: number, overrideNodeDat
   }
 
   deleteNodeAndChildren(selectedNodeId);
-  const socket = SocketSlice.getState().socket;
+  const socket = useSocketStore.getState().socket;
   if (socket) {
     socket.off("updateNode");
     socket.emit("updateNode", newNodeData);

--- a/client/src/store/NodeListProvider.tsx
+++ b/client/src/store/NodeListProvider.tsx
@@ -33,7 +33,7 @@ export function useNodeListContext() {
 export default function NodeListProvider({ children }: { children: ReactNode }) {
   const [data, setData] = useState({});
   const [selectedNode, setSelectedNode] = useState({ nodeId: 0, parentNodeId: 0 });
-  const { saveHistory, undo, redo, history } = useHistoryState<NodeData>(JSON.stringify(data));
+  const { saveHistory, overrideHistory, undo, redo, history } = useHistoryState<NodeData>(JSON.stringify(data));
   const [title, setTitle] = useState(mindMapInfo.title);
   const [loading, setLoading] = useState(true);
 
@@ -43,6 +43,7 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
     setLoading(true);
     setTimeout(() => {
       setData({ ...initialData });
+      overrideHistory(JSON.stringify(initialData));
       setLoading(false);
     }, 0);
   });

--- a/client/src/store/NodeListProvider.tsx
+++ b/client/src/store/NodeListProvider.tsx
@@ -1,8 +1,7 @@
 import useHistoryState from "@/hooks/useHistoryState";
-import initializeNodePosition from "@/konva_mindmap/utils/initializeNodePosition";
 import { Node, NodeData, SelectedNode } from "@/types/Node";
-import { createContext, ReactNode, useContext, useEffect, useState } from "react";
-import { SocketSlice } from "./SocketSlice";
+import { createContext, ReactNode, useContext, useState } from "react";
+import { useSocketStore } from "./useSocketStore";
 
 export type NodeListContextType = {
   data: NodeData | null;
@@ -37,7 +36,7 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
   const [title, setTitle] = useState(mindMapInfo.title);
   const [loading, setLoading] = useState(true);
 
-  const socket = SocketSlice((state) => state.socket);
+  const socket = useSocketStore((state) => state.socket);
 
   socket?.on("joinRoom", (initialData) => {
     setLoading(true);

--- a/client/src/store/SocketSlice.ts
+++ b/client/src/store/SocketSlice.ts
@@ -12,7 +12,7 @@ type SocketState = {
 type HandleSocketEventProps = {
   actionType: actionType;
   payload: createNodePayload | updateNodePayload | deleteNodePayload;
-  callback?: () => void;
+  callback?: (response?: any) => void;
 };
 
 export const SocketSlice = create<SocketState>((set, get) => ({
@@ -43,7 +43,7 @@ export const SocketSlice = create<SocketState>((set, get) => ({
     socket.emit(actionType, payload);
 
     socket.on(actionType, (response) => {
-      if (response && callback) callback();
+      if (response && callback) callback(response);
     });
   },
 }));

--- a/client/src/store/SocketSlice.ts
+++ b/client/src/store/SocketSlice.ts
@@ -1,12 +1,15 @@
 import { Socket, io } from "socket.io-client";
 import { create } from "zustand";
 import { actionType, createNodePayload, updateNodePayload, deleteNodePayload } from "@/types/NodePayload";
+import { createMindmap } from "@/api/mindmap.api";
+import { NavigateFunction } from "react-router-dom";
 
 type SocketState = {
   socket: Socket | null;
   connectSocket: (id: string) => void;
   disconnectSocket: () => void;
   handleSocketEvent: (props: HandleSocketEventProps) => void;
+  handleConnection: (navigate: NavigateFunction, targetMode: string) => void;
 };
 
 type HandleSocketEventProps = {
@@ -45,5 +48,18 @@ export const SocketSlice = create<SocketState>((set, get) => ({
     socket.on(actionType, (response) => {
       if (response && callback) callback(response);
     });
+  },
+
+  handleConnection: async (navigate: NavigateFunction, targetMode: string) => {
+    try {
+      const socket = get().socket;
+      if (socket) socket.disconnect();
+      const response = await createMindmap();
+      const newMindMapId = response.data;
+      get().connectSocket(newMindMapId);
+      navigate(`/mindmap/${newMindMapId}?mode=${targetMode}`);
+    } catch (error) {
+      console.error(error);
+    }
   },
 }));

--- a/client/src/store/useSocketStore.ts
+++ b/client/src/store/useSocketStore.ts
@@ -18,7 +18,7 @@ type HandleSocketEventProps = {
   callback?: (response?: any) => void;
 };
 
-export const SocketSlice = create<SocketState>((set, get) => ({
+export const useSocketStore = create<SocketState>((set, get) => ({
   socket: null,
 
   connectSocket: (id) => {


### PR DESCRIPTION
#35 

## 작업 내용
### 추가 소켓 연결
- 노드 초기화를 할 때 (`resetAllNode`), `deleteNode` 이벤트가 아니라 `updateNode`를 보내도록 변경 (서버 로직과 동기화)
- 노드 재정렬 버튼을 눌렀을 때, 재정렬된 위치를 담아 `updateNode` 이벤트를 발생시키도록 변경
- 사이드바의 버튼들을 눌렀을 때 소켓 연결이 열리도록 변경
    - 연결이 없으면 새로 만들고, 있을 경우 viewMode만 바꿉니다

### 리팩토링 및 에러 해결
- `useHistoryState`에서, `pointer`가 0일 때도 `undo`가 불가능하도록 변경 (원래는 -1까지 갈 수 있어서 에러가 났음)
- `updateNode` 이벤트 중복 등록으로 인한 `saveHistory` 중복 호출 및 history 꼬임 문제 해결
- `socketSlice`에 정의되어 있는 `handleSocketEvent`로 소켓 호출을 통일하여, 이벤트 해지 및 등록을 일관되게 관리
   - `deleteNode`는 추후 변경 예정입니다 (현재 로직 수정 중이라고 들었습니다)
- `socketSlice` -> `useSocketStore` 이름 변경
    - 슬라이스 패턴을 사용할 것이라 생각해서 이렇게 이름을 지어뒀지만... 아니라서 수정했습니다

## 논의하고 싶은 내용