### PR TITLE
[Feature-3-16-fe] 사용자는 각 단축키를 통해 캔버스의 마인드맵을 조작할 수 있다.

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -28,6 +28,7 @@
         "react-dom": "^18.3.1",
         "react-icons": "^5.3.0",
         "react-error-boundary": "^4.1.2",
+        "react-icons": "^5.3.0",
         "react-konva": "^18.2.10",
         "react-konva-utils": "^1.0.6",
         "react-router-dom": "^6.27.0",
@@ -7606,6 +7607,15 @@
       },
       "peerDependencies": {
         "react": ">=16.13.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,7 @@
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
     "react-error-boundary": "^4.1.2",
+    "react-icons": "^5.3.0",
     "react-konva": "^18.2.10",
     "react-konva-utils": "^1.0.6",
     "react-router-dom": "^6.27.0",

--- a/client/src/assets/boomap-icons.svg
+++ b/client/src/assets/boomap-icons.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <symbol id="textfile" viewBox="0 0 33 36">
+    <path fill="#565868" d="M17.366 32.184V36h3.682l8.978-9.306-3.682-3.816-8.978 9.306zM27.785 10.8L17.366 0H3.473C1.563 0 .017 1.62.017 3.6L0 32.4C0 34.38 1.546 36 3.456 36h10.437v-5.31l13.892-14.4V10.8zM15.63 12.6V2.7l9.552 9.9H15.63zm16.862 9l-1.233-1.278a1.687 1.687 0 0 0-2.448 0L27.578 21.6l3.681 3.816 1.233-1.278a1.84 1.84 0 0 0 0-2.538z" />
+  </symbol>
+  <symbol id="pencil" viewBox="0 0 60 60">
+    <path fill="url(#a)" d="M0 0h60v60H0z" />
+    <defs>
+      <pattern id="a" width="1" height="1" patternContentUnits="objectBoundingBox">
+        <use transform="scale(.01042)" xlink:href="#b" />
+      </pattern>
+    </defs>
+  </symbol>
+  <symbol id="bulb" viewBox="0 0 63 63">
+    <g clip-path="url(#a)">
+      <mask id="b" width="63" height="63" x="0" y="0" maskUnits="userSpaceOnUse" style="mask-type:luminance">
+        <path fill="#fff" d="M0 0h63v63H0V0z" />
+      </mask>
+      <g mask="url(#b)">
+        <path fill="#8391FF" d="M49.737 19.994c0 10.675-8.29 12.333-8.29 22.282 0 5.136-5.177 5.57-9.118 5.57-3.404 0-10.919-1.292-10.919-5.573 0-9.946-8.147-11.604-8.147-22.279 0-9.999 8.762-18.104 18.375-18.104 9.615 0 18.099 8.105 18.099 18.104z" />
+        <path fill="#CCCEDD" d="M38.408 55.54c0 1.372-3.703 4.144-6.908 4.144-3.205 0-6.907-2.772-6.907-4.144 0-1.373 3.702-.83 6.907-.83s6.908-.543 6.908.83z" />
+        <path fill="#4D61FF" d="M39.304 18.723a1.659 1.659 0 0 0-2.344 0l-5.46 5.46-5.46-5.46a1.657 1.657 0 1 0-2.343 2.344l6.145 6.146v17.55a1.658 1.658 0 1 0 3.316 0v-17.55l6.146-6.146a1.657 1.657 0 0 0 0-2.344z" />
+        <path fill="#565868" d="M41.447 53.053a3.316 3.316 0 0 1-3.315 3.316H24.869a3.316 3.316 0 0 1-3.316-3.316v-9.947h19.894v9.947z" />
+        <path fill="#CCCEDD" d="M21.55 54.71a1.658 1.658 0 0 1-.271-3.292l19.896-3.316a1.648 1.648 0 0 1 1.907 1.363 1.655 1.655 0 0 1-1.363 1.907l-19.893 3.316c-.09.015-.183.023-.275.023zm0-6.63a1.658 1.658 0 0 1-.271-3.294l19.896-3.315a1.651 1.651 0 0 1 1.887 2.009 1.656 1.656 0 0 1-1.343 1.26l-19.893 3.316c-.09.016-.183.024-.275.023z" />
+      </g>
+    </g>
+    <defs>
+      <clipPath id="a">
+        <path fill="#fff" d="M0 0h63v63H0z" />
+      </clipPath>
+    </defs>
+  </symbol>
+  <symbol id="cloud" viewBox="0 0 466 435">
+    <path fill="url(#a)" d="M0 0h466v435H0z" />
+    <defs>
+      <pattern id="a" width="1" height="1" patternContentUnits="objectBoundingBox">
+        <use transform="matrix(.00222 0 0 .00238 0 -.036)" xlink:href="#b" />
+      </pattern>
+    </defs>
+  </symbol>
+  <symbol id="boomap" viewBox="0 0 72 72">
+    <path fill="url(#a)" d="M0 0h72v72H0z" />
+    <defs>
+      <pattern id="a" width="1" height="1" patternContentUnits="objectBoundingBox">
+        <use transform="scale(.00195)" xlink:href="#b" />
+      </pattern>
+    </defs>
+  </symbol>
+</svg>

--- a/client/src/components/MindMapCanvas/ToolMenu.tsx
+++ b/client/src/components/MindMapCanvas/ToolMenu.tsx
@@ -2,7 +2,7 @@ import { Button } from "@headlessui/react";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { StageDimension } from "@/konva_mindmap/types/dimension";
 import { showNewNode } from "@/konva_mindmap/events/addNode";
-import { deleteNode } from "@/konva_mindmap/events/deleteNode";
+import { deleteNodes } from "@/konva_mindmap/events/deleteNode";
 import { useRef } from "react";
 import { FaRegHandPaper } from "react-icons/fa";
 import { PiCursorFill } from "react-icons/pi";
@@ -38,7 +38,7 @@ export default function ToolMenu({ dimensions, zoomIn, zoomOut, dragmode, setDra
   }
   function handleDeleteButton() {
     saveHistory(JSON.stringify(data));
-    deleteNode(JSON.stringify(data), selectedNode.nodeId, overrideNodeData);
+    deleteNodes(JSON.stringify(data), selectedNode.nodeId, overrideNodeData);
     selectNode({ nodeId: 0, parentNodeId: 0 });
   }
 

--- a/client/src/components/MindMapCanvas/ToolMenu.tsx
+++ b/client/src/components/MindMapCanvas/ToolMenu.tsx
@@ -1,20 +1,24 @@
-import plusIcon from "@/assets/plus.png";
-import minusIcon from "@/assets/minus.png";
-import addElementIcon from "@/assets/addElement.png";
-import deleteIcon from "@/assets/trash.png";
 import { Button } from "@headlessui/react";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { StageDimension } from "@/konva_mindmap/types/dimension";
 import { showNewNode } from "@/konva_mindmap/events/addNode";
 import { deleteNode } from "@/konva_mindmap/events/deleteNode";
 import { useRef } from "react";
+import { FaRegHandPaper } from "react-icons/fa";
+import { PiCursorFill } from "react-icons/pi";
+import { TiZoomInOutline } from "react-icons/ti";
+import { TiZoomOutOutline } from "react-icons/ti";
+import { FaRegTrashAlt } from "react-icons/fa";
+import { TbCirclePlus2 } from "react-icons/tb";
 
 type ToolMenuProps = {
   dimensions: StageDimension;
   zoomIn: () => void;
   zoomOut: () => void;
+  dragmode: boolean;
+  setDragmode: React.Dispatch<React.SetStateAction<boolean>>;
 };
-export default function ToolMenu({ dimensions, zoomIn, zoomOut }: ToolMenuProps) {
+export default function ToolMenu({ dimensions, zoomIn, zoomOut, dragmode, setDragmode }: ToolMenuProps) {
   const { data, selectNode, selectedNode, saveHistory, overrideNodeData } = useNodeListContext();
   const intervalRef = useRef(null);
 
@@ -39,22 +43,51 @@ export default function ToolMenu({ dimensions, zoomIn, zoomOut }: ToolMenuProps)
   }
 
   return (
-    <div className="absolute bottom-2 left-1/2 flex -translate-x-2/4 -translate-y-2/4 items-center gap-3 rounded-full border bg-white px-10 py-2 shadow-md">
-      <div className="flex items-center gap-3 border-r-2 px-5">
-        <Button className="h-5 w-5" onMouseDown={() => startZoom(zoomIn)} onMouseUp={stopZoom} onMouseLeave={stopZoom}>
-          <img src={plusIcon} alt="확대하기" />
+    <div className="absolute bottom-2 left-1/2 flex -translate-x-2/4 -translate-y-2/4 items-center justify-center rounded-full border bg-white px-6 py-2 shadow-md">
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 px-1">
+          <Button
+            className={`rounded-md p-1 hover:bg-blue-300 ${dragmode ? "bg-blue-400" : ""}`}
+            onClick={() => setDragmode(true)}
+          >
+            <FaRegHandPaper
+              className={`mr-[2px] h-[18px] w-[18px] ${dragmode ? "fill-grayscale-100" : "fill-grayscale-400"}`}
+            />
+          </Button>
+          <Button
+            className={`rounded-md p-1 ${dragmode ? "hover:bg-blue-300" : "bg-blue-400"}`}
+            onClick={() => setDragmode(false)}
+          >
+            <PiCursorFill
+              className={`h-5 w-5 hover:fill-grayscale-100 ${dragmode ? "fill-gray-400" : "fill-grayscale-100"}`}
+            />
+          </Button>
+          <div className="flex items-center gap-3 border-x-2 px-3">
+            <Button
+              className="rounded-md p-1 hover:bg-blue-300"
+              onMouseDown={() => startZoom(zoomIn)}
+              onMouseUp={stopZoom}
+            >
+              <TiZoomInOutline className="h-6 w-6 fill-grayscale-400 hover:fill-gray-100" />
+            </Button>
+            <span className="w-8 text-center text-sm font-bold text-black">{Math.floor(dimensions.scale * 100)}%</span>
+            <Button
+              className="rounded-md p-1 hover:bg-blue-300"
+              onMouseDown={() => startZoom(zoomOut)}
+              onMouseUp={stopZoom}
+              onMouseLeave={stopZoom}
+            >
+              <TiZoomOutOutline className="h-6 w-6 fill-grayscale-400 hover:fill-gray-100" />
+            </Button>
+          </div>
+        </div>
+        <Button className="rounded-md fill-gray-100 p-1 hover:bg-blue-300" onClick={handleAddButton}>
+          <TbCirclePlus2 className="mr-1 h-5 w-5 stroke-grayscale-400 hover:fill-gray-100" />
         </Button>
-        <span className="w-8 text-center text-sm font-bold text-black">{Math.floor(dimensions.scale * 100)}%</span>
-        <Button className="h-5 w-5" onMouseDown={() => startZoom(zoomOut)} onMouseUp={stopZoom} onMouseLeave={stopZoom}>
-          <img src={minusIcon} alt="축소하기" />
+        <Button className="rounded-md p-1 hover:bg-blue-300" onClick={handleDeleteButton}>
+          <FaRegTrashAlt className="h-[18px] w-[18px] fill-grayscale-400 hover:fill-gray-100" />
         </Button>
       </div>
-      <Button className="w-8 border-r-2 pr-2" onClick={handleAddButton}>
-        <img src={addElementIcon} alt="요소 추가" />
-      </Button>
-      <Button className="h-5 w-5" onClick={handleDeleteButton}>
-        <img src={deleteIcon} alt="요소 삭제" />
-      </Button>
     </div>
   );
 }

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -16,6 +16,7 @@ import DrawMindMap from "@/konva_mindmap/components/DrawMindMap";
 import ShowShortCut from "./ShowShortCut";
 import { findRootNodeKey } from "@/konva_mindmap/utils/findRootNodeKey";
 import { useSocketStore } from "@/store/useSocketStore";
+import { showNewNode } from "@/konva_mindmap/events/addNode";
 
 export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
   const {
@@ -26,6 +27,9 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
     overrideNodeData,
     saveHistory,
     loading,
+    selectedGroup,
+    deleteSelectedNodes,
+    selectedNode,
   } = useNodeListContext();
   const { dimensions, targetRef, handleWheel, zoomIn, zoomOut } = useDimension(data);
   const { registerStageRef } = useStageStore();
@@ -40,10 +44,6 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
     registerStageRef(stageRef);
   }, [stageRef]);
 
-  const commandKeyMap = {
-    z: undo,
-    y: redo,
-  };
   function handleReArrange() {
     handleSocketEvent({
       actionType: "updateNode",
@@ -58,11 +58,32 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
   }
 
   useWindowKeyEventListener("keydown", (e) => {
-    if (e.ctrlKey || e.metaKey) {
-      commandKeyMap[e.key]?.();
+    e.preventDefault();
+    if (e.metaKey || e.ctrlKey) {
+      if (e.shiftKey && e.code) redo();
+      switch (e.code) {
+        case "KeyZ":
+          undo();
+          break;
+        case "KeyR":
+          const url = window.location;
+          location.href = url.pathname;
+          break;
+      }
     }
-    if (e.code === "Space") {
-      setDragMode(true);
+
+    switch (e.code) {
+      case "Space":
+        setDragMode(true);
+        break;
+      case "Backspace":
+        deleteSelectedNodes();
+        break;
+      case "Equal":
+        showNewNode(data, selectedNode, overrideNodeData);
+        break;
+      default:
+        break;
     }
   });
 

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -88,7 +88,7 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
       >
         <Layer ref={registerLayer}>
           {Object.keys(data).length >= 1 && (
-            <MindMapNode data={data} node={data[rootKey]} depth={1} dragmode={isDragMode} />
+            <DrawMindMap data={data} root={data[rootKey]} depth={1} dragmode={isDragMode} />
           )}
           <SelectionRect stage={stageRef} dragmode={isDragMode} />
         </Layer>

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -1,15 +1,18 @@
 import useDimension from "@/konva_mindmap/hooks/useDimension";
 import useWindowKeyEventListener from "@/hooks/useWindowKeyEventListener";
-import DrawMindMap from "@/konva_mindmap/components/DrawMindMap";
 import ToolMenu from "@/components/MindMapCanvas/ToolMenu";
 import initializeNodePosition from "@/konva_mindmap/utils/initializeNodePosition";
 import { Layer, Stage } from "react-konva";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { useCollisionDetection } from "@/konva_mindmap/hooks/useCollisionDetection";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useStageStore } from "@/store/useStageStore";
 import NoNodeInform from "@/components/MindMapCanvas/NoNodeInform";
 import CanvasButtons from "@/components/MindMapCanvas/CanvasButtons";
+import MindMapNode from "@/konva_mindmap/components/MindMapNode";
+import Konva from "konva";
+import SelectionRect from "@/konva_mindmap/components/selectionRect";
+import DrawMindMap from "@/konva_mindmap/components/DrawMindMap";
 import ShowShortCut from "./ShowShortCut";
 import { findRootNodeKey } from "@/konva_mindmap/utils/findRootNodeKey";
 import { useSocketStore } from "@/store/useSocketStore";
@@ -25,9 +28,10 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
     loading,
   } = useNodeListContext();
   const { dimensions, targetRef, handleWheel, zoomIn, zoomOut } = useDimension(data);
-  const registerLayer = useCollisionDetection(data, updateNode);
-  const stageRef = useRef();
   const { registerStageRef } = useStageStore();
+  const registerLayer = useCollisionDetection(data, updateNode);
+  const stageRef = useRef<Konva.Stage>(null);
+  const [isDragMode, setDragMode] = useState(false);
   const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
 
   const rootKey = findRootNodeKey(data);
@@ -55,7 +59,16 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
 
   useWindowKeyEventListener("keydown", (e) => {
     if (e.ctrlKey || e.metaKey) {
-      commandKeyMap[e.key]();
+      commandKeyMap[e.key]?.();
+    }
+    if (e.code === "Space") {
+      setDragMode(true);
+    }
+  });
+
+  useWindowKeyEventListener("keyup", (e) => {
+    if (e.code === "Space") {
+      setDragMode(false);
     }
   });
 
@@ -63,22 +76,31 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
     <div ref={targetRef} className="relative h-full min-h-0 w-full min-w-0 rounded-[20px] bg-white">
       <Stage
         ref={stageRef}
-        className="cursor-pointer"
         width={dimensions.width}
         height={dimensions.height}
         scaleX={dimensions.scale}
         scaleY={dimensions.scale}
         x={dimensions.x}
         y={dimensions.y}
-        draggable
         onWheel={handleWheel}
+        draggable={isDragMode}
+        className={`${isDragMode ? "cursor-pointer" : ""}`}
       >
         <Layer ref={registerLayer}>
-          {Object.keys(data).length >= 1 && <DrawMindMap data={data} root={data[rootKey]} depth={1} />}
+          {Object.keys(data).length >= 1 && (
+            <MindMapNode data={data} node={data[rootKey]} depth={1} dragmode={isDragMode} />
+          )}
+          <SelectionRect stage={stageRef} dragmode={isDragMode} />
         </Layer>
       </Stage>
       <ShowShortCut />
-      <ToolMenu dimensions={dimensions} zoomIn={zoomIn} zoomOut={zoomOut} />
+      <ToolMenu
+        dimensions={dimensions}
+        zoomIn={zoomIn}
+        zoomOut={zoomOut}
+        dragmode={isDragMode}
+        setDragmode={setDragMode}
+      />
       {!Object.keys(data).length && !loading ? (
         <NoNodeInform />
       ) : (

--- a/client/src/components/MindMapHeader/MindMapHeaderButtons.tsx
+++ b/client/src/components/MindMapHeader/MindMapHeaderButtons.tsx
@@ -5,8 +5,8 @@ import { useStageStore } from "@/store/useStageStore";
 import { Button } from "@headlessui/react";
 
 export default function MindMapHeaderButtons() {
+  const stage = useStageStore((state) => state.stage);
   function handleExport() {
-    const stage = useStageStore((state) => state.stage);
     downloadURI(stage.current.getStage().toDataURL({ mimeType: "image/png", quality: 1 }), "demo");
   }
   return (

--- a/client/src/components/MindMapMainSection/ControlSection/ListView/NodeItem.tsx
+++ b/client/src/components/MindMapMainSection/ControlSection/ListView/NodeItem.tsx
@@ -6,7 +6,7 @@ import { Input } from "@headlessui/react";
 import useNodeActions from "@/hooks/useNodeActions";
 import bulletPointIcon from "@/assets/bulletPoint.png";
 import { useNodeListContext } from "@/store/NodeListProvider";
-import { deleteNode } from "@/konva_mindmap/events/deleteNode";
+import { deleteNodes } from "@/konva_mindmap/events/deleteNode";
 import { showNewNode } from "@/konva_mindmap/events/addNode";
 import { useEffect, useRef } from "react";
 import { Node } from "@/types/Node";
@@ -67,7 +67,7 @@ export default function NodeItem({ node, parentNodeId, open, handleAccordion, op
 
   function handleDeleteButton() {
     saveHistory(JSON.stringify(data));
-    deleteNode(JSON.stringify(data), node.id, overrideNodeData);
+    deleteNodes(JSON.stringify(data), node.id, overrideNodeData);
   }
 
   const selectedBorder = selectedNode.nodeId === node.id ? "border-2 border-blue-500" : "border-2 border-grayscale-600";

--- a/client/src/components/MindMapMainSection/ControlSection/TextUpload.tsx
+++ b/client/src/components/MindMapMainSection/ControlSection/TextUpload.tsx
@@ -12,6 +12,7 @@ export default function TextUpload() {
         <Textarea
           className="h-full w-full resize-none rounded-xl bg-grayscale-600 p-4"
           placeholder="Text를 넣어주세요. (500자 이상 2000자 이하)"
+          onKeyDown={(e) => e.stopPropagation()}
           onChange={(e) => setContent(e.target.value)}
         />
         <p className="text-right text-grayscale-400">

--- a/client/src/components/Minutes/index.tsx
+++ b/client/src/components/Minutes/index.tsx
@@ -13,6 +13,7 @@ export default function Minutes({ showMinutes, isAnimating, handleIsAnimating })
 
   function handleMouseDown(e: React.MouseEvent) {
     e.preventDefault();
+    e.stopPropagation();
     handleIsAnimating();
     startXRef.current = e.clientX;
     startWidthRef.current = width;

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -3,18 +3,22 @@ import { useAuthStore } from "@/store/useAuthStore";
 import { getToken, removeToken } from "@/utils/token";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 
 export default function useAuth() {
   const accessToken = getToken();
   const auth = useAuthStore();
+  const navigate = useNavigate();
+
   const { isLoading, isError } = useQuery({
     queryKey: ["user"],
     queryFn: getUser,
     enabled: !!(accessToken || auth.isAuthenticated),
   });
+
   useEffect(() => {
     if (isError) {
-      removeToken();
+      navigate("/error");
     }
   }, [isError]);
   return { isLoading };

--- a/client/src/hooks/useGroupSelect.ts
+++ b/client/src/hooks/useGroupSelect.ts
@@ -1,0 +1,14 @@
+import Konva from "konva";
+import { useState } from "react";
+
+export default function useGroupSelect() {
+  const [selectedGroup, setSelectedGroup] = useState([]);
+  function groupSelect(group: Konva.Group[]) {
+    const selectedNodes = group.map((node) => node.attrs.id);
+    setSelectedGroup(selectedNodes);
+  }
+  function groupRelease() {
+    setSelectedGroup([]);
+  }
+  return { groupSelect, groupRelease, selectedGroup };
+}

--- a/client/src/hooks/useNodeActions.ts
+++ b/client/src/hooks/useNodeActions.ts
@@ -43,6 +43,7 @@ export default function useNodeActions(id: number, content: string) {
   }
 
   function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    e.stopPropagation();
     if (e.key == "Enter") saveContent();
   }
 

--- a/client/src/hooks/useWindowKeyEventListener.ts
+++ b/client/src/hooks/useWindowKeyEventListener.ts
@@ -1,10 +1,10 @@
 import { useEffect } from "react";
 
 export default function useWindowKeyEventListener(eventType: string, eventHandler: (event: KeyboardEvent) => void) {
-    useEffect(() => {
-        window.addEventListener(eventType, eventHandler);
-        return () => {
-            window.removeEventListener(eventType, eventHandler);
-        };
-    }, [eventType, eventHandler]);
+  useEffect(() => {
+    window.addEventListener(eventType, eventHandler);
+    return () => {
+      window.removeEventListener(eventType, eventHandler);
+    };
+  }, [eventType, eventHandler]);
 }

--- a/client/src/konva_mindmap/components/DrawMindMap.tsx
+++ b/client/src/konva_mindmap/components/DrawMindMap.tsx
@@ -9,21 +9,24 @@ type MindMapProps = {
   depth?: number;
   parentNode?: any;
   update?: (id: number, node: Node) => void;
+  dragmode: boolean;
 };
 
-export default function DrawMindMap({ data, root, depth = 0, parentNode }: MindMapProps) {
+export default function DrawMindMap({ data, root, depth = 0, parentNode, dragmode }: MindMapProps) {
   return (
     <>
-      <MindMapNode data={data} depth={depth} parentNode={parentNode} node={root} />
+      {parentNode && (
+        <ConnectedLine
+          from={parentNode.location}
+          to={root.location}
+          fromRadius={70 - depth * 10}
+          toRadius={60 - depth * 10}
+        />
+      )}
+      <MindMapNode data={data} depth={depth} parentNode={parentNode} node={root} dragmode={dragmode} />
       {root.children?.map((childNode, index) => (
         <React.Fragment key={index}>
-          <ConnectedLine
-            from={root.location}
-            to={data[childNode].location}
-            fromRadius={70 - (depth + 1) * 10}
-            toRadius={60 - (depth + 1) * 10}
-          />
-          <DrawMindMap data={data} root={data[childNode]} depth={depth + 1} parentNode={root} />
+          <DrawMindMap data={data} root={data[childNode]} depth={depth + 1} parentNode={root} dragmode={dragmode} />
         </React.Fragment>
       ))}
     </>

--- a/client/src/konva_mindmap/components/EditableText.tsx
+++ b/client/src/konva_mindmap/components/EditableText.tsx
@@ -54,6 +54,7 @@ export default function EditableText({
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    e.stopPropagation();
     if (e.key === "Enter") saveContent();
   }
 

--- a/client/src/konva_mindmap/components/MindMapNode.tsx
+++ b/client/src/konva_mindmap/components/MindMapNode.tsx
@@ -3,11 +3,10 @@ import EditableText from "@/konva_mindmap/components/EditableText";
 import { NodeProps } from "@/types/Node";
 import { Circle, Group } from "react-konva";
 import { useNodeListContext } from "@/store/NodeListProvider";
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useSocketStore } from "@/store/useSocketStore";
-import { checkFollowing, reconcileOffsets, resetSavedOffsets, saveOffsets } from "@/konva_mindmap/utils/following";
+import { checkFollowing, resetSavedOffsets, saveOffsets } from "@/konva_mindmap/utils/following";
 import { colors } from "@/constants/color";
-import ConnectedLine from "@/konva_mindmap/components/ConnectedLine";
 import Konva from "konva";
 import { getMovedNodesLocation } from "@/konva_mindmap/utils/select";
 
@@ -24,18 +23,18 @@ export default function MindMapNode({ data, parentNode, node, depth, parentRef, 
   }
 
   function handleDragEnd() {
-    const reconciledData = reconcileOffsets(data, node, updateNode);
     resetSavedOffsets();
     handleSocketEvent({
       actionType: "updateNode",
-      payload: reconciledData,
+      payload: data,
       callback: () => {
-        saveHistory(JSON.stringify(reconciledData));
+        saveHistory(JSON.stringify(data));
       },
     });
   }
 
-  function handleClick() {
+  function handleClick(e) {
+    e.evt.preventDefault();
     if (selectedNode.nodeId === node.id) {
       selectNode({ nodeId: 0, parentNodeId: 0 });
       return;
@@ -46,6 +45,7 @@ export default function MindMapNode({ data, parentNode, node, depth, parentRef, 
   const NodeStroke = selectedGroup.includes(node.id.toString()) ? "red" : "";
 
   const handleDragMove = (e: Konva.KonvaEventObject<DragEvent>) => {
+    e.evt.preventDefault();
     const currentPos = { x: e.target.x(), y: e.target.y() };
     const dx = currentPos.x - node.location.x;
     const dy = currentPos.y - node.location.y;
@@ -64,8 +64,6 @@ export default function MindMapNode({ data, parentNode, node, depth, parentRef, 
     if (e.evt.ctrlKey || e.evt.metaKey) {
       checkFollowing(data, node, currentPos, updateNode);
     }
-
-    // 현재 노드 업데이트
   };
 
   return (
@@ -75,15 +73,12 @@ export default function MindMapNode({ data, parentNode, node, depth, parentRef, 
         onDblClick={handleDoubleClick}
         name="node"
         id={node.id.toString()}
-        onDragStart={() => {
+        onDragStart={(e) => {
+          e.evt.preventDefault();
           saveOffsets(data, node);
         }}
         onDragMove={handleDragMove}
-        onDragEnd={() => {
-          // reconcileOffsets(data, node, updateNode);
-          resetSavedOffsets();
-          saveHistory(JSON.stringify(data));
-        }}
+        onDragEnd={handleDragEnd}
         draggable={!dragmode}
         x={node.location.x}
         y={node.location.y}
@@ -109,26 +104,6 @@ export default function MindMapNode({ data, parentNode, node, depth, parentRef, 
           setIsEditing={setIsEditing}
         />
       </Group>
-      {parentNode && (
-        <ConnectedLine
-          from={parentNode.location}
-          to={node.location}
-          fromRadius={70 - depth * 10}
-          toRadius={60 - depth * 10}
-        />
-      )}
-      {node.children?.map((childNode, index) => (
-        <React.Fragment key={index}>
-          <MindMapNode
-            data={data}
-            node={data[childNode]}
-            depth={depth + 1}
-            parentNode={node}
-            parentRef={nodeRef}
-            dragmode={dragmode}
-          />
-        </React.Fragment>
-      ))}
     </>
   );
 }

--- a/client/src/konva_mindmap/components/MindMapNode.tsx
+++ b/client/src/konva_mindmap/components/MindMapNode.tsx
@@ -61,7 +61,7 @@ export default function MindMapNode({ data, parentNode, node, depth, parentRef, 
       location: currentPos,
     });
 
-    if (e.evt.ctrlKey || e.evt.metaKey) {
+    if (e.evt.shiftKey) {
       checkFollowing(data, node, currentPos, updateNode);
     }
   };

--- a/client/src/konva_mindmap/components/MindMapNode.tsx
+++ b/client/src/konva_mindmap/components/MindMapNode.tsx
@@ -1,29 +1,26 @@
+import NewNode from "@/konva_mindmap/components/NewNode";
 import EditableText from "@/konva_mindmap/components/EditableText";
 import { NodeProps } from "@/types/Node";
 import { Circle, Group } from "react-konva";
 import { useNodeListContext } from "@/store/NodeListProvider";
-import { useState } from "react";
+import React, { useRef, useState } from "react";
 import { useSocketStore } from "@/store/useSocketStore";
 import { checkFollowing, reconcileOffsets, resetSavedOffsets, saveOffsets } from "@/konva_mindmap/utils/following";
-import NewNode from "@/konva_mindmap/components/NewNode";
 import { colors } from "@/constants/color";
+import ConnectedLine from "@/konva_mindmap/components/ConnectedLine";
+import Konva from "konva";
+import { getMovedNodesLocation } from "@/konva_mindmap/utils/select";
 
-export default function MindMapNode({ data, parentNode, node, depth }: NodeProps) {
-  if (node.newNode) return <NewNode data={data} parentNode={parentNode} node={node} depth={depth} />;
-  const { saveHistory, updateNode, selectNode, selectedNode } = useNodeListContext();
+export default function MindMapNode({ data, parentNode, node, depth, parentRef, dragmode }: NodeProps) {
+  if (node.newNode)
+    return <NewNode data={data} parentNode={parentNode} node={node} depth={depth} dragmode={dragmode} />;
+  const nodeRef = useRef<Konva.Group>(null);
+  const { saveHistory, updateNode, selectNode, selectedNode, selectedGroup, overrideNodeData } = useNodeListContext();
   const [isEditing, setIsEditing] = useState(false);
   const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
 
   function handleDoubleClick() {
     setIsEditing(true);
-  }
-
-  function handleMouseEnter() {
-    this.setStroke("red");
-  }
-
-  function handleMouseLeave() {
-    this.setStroke("");
   }
 
   function handleDragEnd() {
@@ -45,50 +42,93 @@ export default function MindMapNode({ data, parentNode, node, depth }: NodeProps
     }
     selectNode({ nodeId: node.id, parentNodeId: parentNode ? parentNode.id : null });
   }
+
+  const NodeStroke = selectedGroup.includes(node.id.toString()) ? "red" : "";
+
+  const handleDragMove = (e: Konva.KonvaEventObject<DragEvent>) => {
+    const currentPos = { x: e.target.x(), y: e.target.y() };
+    const dx = currentPos.x - node.location.x;
+    const dy = currentPos.y - node.location.y;
+
+    if (selectedGroup.length) {
+      const groupMove = getMovedNodesLocation(data, selectedGroup, node, dx, dy, currentPos);
+      overrideNodeData(groupMove);
+      return;
+    }
+
+    updateNode(node.id, {
+      ...node,
+      location: currentPos,
+    });
+
+    if (e.evt.ctrlKey || e.evt.metaKey) {
+      checkFollowing(data, node, currentPos, updateNode);
+    }
+
+    // 현재 노드 업데이트
+  };
+
   return (
-    <Group
-      onDblClick={handleDoubleClick}
-      name="node"
-      id={node.id.toString()}
-      onDragStart={() => {
-        saveOffsets(data, node);
-      }}
-      onDragMove={(e) => {
-        updateNode(node.id, {
-          ...node,
-          location: {
-            x: e.target.x(),
-            y: e.target.y(),
-          },
-        });
-        checkFollowing(data, node, updateNode);
-      }}
-      onDragEnd={handleDragEnd}
-      draggable
-      x={node.location.x}
-      y={node.location.y}
-      onClick={handleClick}
-    >
-      <Circle
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        fill={selectedNode?.nodeId === node.id ? "orange" : colors[depth - 1]}
-        width={100}
-        height={100}
-        strokeWidth={3}
-        radius={60 - depth * 10}
-        shadowBlur={5}
-      />
-      <EditableText
-        id={node.id}
-        name="text"
-        text={node.keyword}
-        offsetX={70 - depth * 10}
-        offsetY={8 * depth - 60}
-        width={140 - depth * 20}
-        isEditing={isEditing}
-        setIsEditing={setIsEditing}
-      />
-    </Group>
+    <>
+      <Group
+        ref={nodeRef}
+        onDblClick={handleDoubleClick}
+        name="node"
+        id={node.id.toString()}
+        onDragStart={() => {
+          saveOffsets(data, node);
+        }}
+        onDragMove={handleDragMove}
+        onDragEnd={() => {
+          // reconcileOffsets(data, node, updateNode);
+          resetSavedOffsets();
+          saveHistory(JSON.stringify(data));
+        }}
+        draggable={!dragmode}
+        x={node.location.x}
+        y={node.location.y}
+        onClick={handleClick}
+      >
+        <Circle
+          stroke={NodeStroke}
+          fill={selectedNode?.nodeId === node.id ? "orange" : colors[depth - 1]}
+          width={100}
+          height={100}
+          strokeWidth={3}
+          radius={60 - depth * 10}
+          shadowBlur={5}
+        />
+        <EditableText
+          id={node.id}
+          name="text"
+          text={node.keyword}
+          offsetX={70 - depth * 10}
+          offsetY={8 * depth - 60}
+          width={140 - depth * 20}
+          isEditing={isEditing}
+          setIsEditing={setIsEditing}
+        />
+      </Group>
+      {parentNode && (
+        <ConnectedLine
+          from={parentNode.location}
+          to={node.location}
+          fromRadius={70 - depth * 10}
+          toRadius={60 - depth * 10}
+        />
+      )}
+      {node.children?.map((childNode, index) => (
+        <React.Fragment key={index}>
+          <MindMapNode
+            data={data}
+            node={data[childNode]}
+            depth={depth + 1}
+            parentNode={node}
+            parentRef={nodeRef}
+            dragmode={dragmode}
+          />
+        </React.Fragment>
+      ))}
+    </>
   );
 }

--- a/client/src/konva_mindmap/components/NewNode.tsx
+++ b/client/src/konva_mindmap/components/NewNode.tsx
@@ -34,6 +34,7 @@ export default function NewNode({ data, node, depth }: NodeProps) {
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    e.stopPropagation();
     if (e.key === "Enter") saveContent();
   }
 

--- a/client/src/konva_mindmap/components/selectionRect.tsx
+++ b/client/src/konva_mindmap/components/selectionRect.tsx
@@ -1,0 +1,92 @@
+import { getSelectedNodes } from "@/konva_mindmap/utils/select";
+import { useNodeListContext } from "@/store/NodeListProvider";
+import Konva from "konva";
+import { RefObject, useEffect, useRef, useState } from "react";
+import { Rect } from "react-konva";
+
+export default function SelectionRect({ stage, dragmode }: { stage: RefObject<Konva.Stage>; dragmode: boolean }) {
+  const { groupSelect, groupRelease } = useNodeListContext();
+  const [rectOption, setRectOption] = useState({
+    visible: false,
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+  });
+  const [startPoint, setStartPoint] = useState({ x: 0, y: 0 });
+  const selectionRectangle = useRef<Konva.Rect>(null);
+  const currentRectRef = useRef(rectOption);
+
+  useEffect(() => {
+    currentRectRef.current = rectOption;
+  }, [rectOption]);
+
+  useEffect(() => {
+    if (!stage.current) return;
+    const currentStage = stage.current;
+
+    const handleMouseDown = (e) => {
+      if (dragmode) return;
+      e.evt.preventDefault();
+      const pos = currentStage.getRelativePointerPosition();
+      setStartPoint({ x: pos.x, y: pos.y });
+
+      const newRectOption = {
+        visible: true,
+        x: pos.x,
+        y: pos.y,
+        width: 0,
+        height: 0,
+      };
+      setRectOption(newRectOption);
+      currentRectRef.current = newRectOption;
+    };
+
+    const handleMouseMove = (e) => {
+      if (!currentRectRef.current.visible || dragmode) return;
+
+      const pos = currentStage.getRelativePointerPosition();
+      const newRectOption = {
+        ...currentRectRef.current,
+        x: Math.min(startPoint.x, pos.x),
+        y: Math.min(startPoint.y, pos.y),
+        width: Math.abs(pos.x - startPoint.x),
+        height: Math.abs(pos.y - startPoint.y),
+      };
+      setRectOption(newRectOption);
+      currentRectRef.current = newRectOption;
+    };
+
+    const handleMouseUp = () => {
+      if (dragmode) return;
+      if (currentRectRef.current.width > 0 && currentRectRef.current.height > 0) {
+        const selectedNodes = getSelectedNodes(currentStage.children[0], currentRectRef.current);
+        groupSelect(selectedNodes as Konva.Group[]);
+      } else groupRelease();
+
+      setRectOption((prev) => ({ ...prev, visible: false }));
+    };
+
+    currentStage.on("mousedown touchstart", handleMouseDown);
+    currentStage.on("mousemove touchmove", handleMouseMove);
+    currentStage.on("mouseup touchend", handleMouseUp);
+
+    return () => {
+      currentStage.off("mousedown touchstart", handleMouseDown);
+      currentStage.off("mousemove touchmove", handleMouseMove);
+      currentStage.off("mouseup touchend", handleMouseUp);
+    };
+  }, [stage, startPoint, groupSelect, dragmode]);
+
+  return (
+    <Rect
+      ref={selectionRectangle}
+      x={rectOption.x}
+      y={rectOption.y}
+      width={rectOption.width}
+      height={rectOption.height}
+      fill="rgba(0, 161, 255, 0.3)"
+      visible={rectOption.visible}
+    />
+  );
+}

--- a/client/src/konva_mindmap/hooks/useAdjustedStage.ts
+++ b/client/src/konva_mindmap/hooks/useAdjustedStage.ts
@@ -8,10 +8,11 @@ export function useAdjustedStage(data: NodeData, containerWidth: number, contain
   const rootKey = findRootNodeKey(data);
 
   useEffect(() => {
+    if (!Object.keys(data).length) return;
     const bounds = calculateBounds(data, rootKey);
     const newDimensions = adjustStageToFit(bounds);
     setAdjustedDimensions(newDimensions);
-  }, [containerWidth, containerHeight, data]);
+  }, [containerWidth, containerHeight]);
 
   //그림이 그려지는 영역 크기 계산
   function calculateBounds(data: NodeData, rootId: number) {

--- a/client/src/konva_mindmap/utils/following.ts
+++ b/client/src/konva_mindmap/utils/following.ts
@@ -59,35 +59,6 @@ export function resetSavedOffsets(): void {
   offsetManager.reset();
 }
 
-export function reconcileOffsets(
-  data: NodeData,
-  root: Node,
-  updateNode: (id: number, updates: Partial<Node>) => void,
-  updatedParentLocation?: Location,
-): NodeData {
-  let updatedData = { ...data };
-
-  if (!root.children || !root.location) return updatedData;
-
-  root.children.forEach((childNodeId) => {
-    const childNode = updatedData[childNodeId];
-    if (!childNode) return;
-
-    const offset = offsetManager.getOffset(childNodeId);
-    if (!offset) return;
-
-    const newLocation = {
-      x: updatedParentLocation ? updatedParentLocation.x + offset.x : root.location.x + offset.x,
-      y: updatedParentLocation ? updatedParentLocation.y + offset.y : root.location.y + offset.y,
-    };
-
-    updatedData[childNode.id] = { ...childNode, location: newLocation };
-    updatedData = reconcileOffsets(updatedData, childNode, updateNode, newLocation);
-  });
-
-  return updatedData;
-}
-
 export function adjustNodePositions(parentNode: Node, targetNode: Node, currPos: Location): Location {
   if (!parentNode.location || !targetNode.location) return;
 

--- a/client/src/konva_mindmap/utils/select.ts
+++ b/client/src/konva_mindmap/utils/select.ts
@@ -1,0 +1,54 @@
+import { Location } from "@/konva_mindmap/types/location";
+import { Node, NodeData } from "@/types/Node";
+import Konva from "konva";
+
+export function getSelectedNodes(layer: Konva.Layer, square) {
+  if (!layer) return [];
+
+  const nodes = layer.children.filter((node) => node.attrs.name === "node");
+
+  const rectBounds = {
+    x1: square.x,
+    y1: square.y,
+    x2: square.x + square.width,
+    y2: square.y + square.height,
+  };
+
+  const selectedNodes = nodes.filter((node) => {
+    const nodeCenter = {
+      x: node.attrs.x,
+      y: node.attrs.y,
+    };
+
+    return (
+      nodeCenter.x >= rectBounds.x1 &&
+      nodeCenter.x <= rectBounds.x2 &&
+      nodeCenter.y >= rectBounds.y1 &&
+      nodeCenter.y <= rectBounds.y2
+    );
+  });
+
+  return selectedNodes;
+}
+
+export function getMovedNodesLocation(
+  data: NodeData,
+  selectedGroup,
+  node: Node,
+  dx: number,
+  dy: number,
+  currentPos: Location,
+) {
+  const result = JSON.parse(JSON.stringify(data));
+  result[node.id].location = currentPos;
+  selectedGroup.forEach((selectedId) => {
+    if (selectedId !== node.id.toString()) {
+      const selectedNode = result[parseInt(selectedId)];
+      result[parseInt(selectedId)].location = {
+        x: selectedNode.location.x + dx,
+        y: selectedNode.location.y + dy,
+      };
+    }
+  });
+  return result;
+}

--- a/client/src/konva_mindmap/utils/throttle.ts
+++ b/client/src/konva_mindmap/utils/throttle.ts
@@ -1,0 +1,10 @@
+export function throttle(fn: any, delay: number) {
+  let timer = null;
+  return (function () {
+    if (timer) return;
+    timer = setTimeout(() => {
+      fn();
+      timer = null;
+    }, delay);
+  })();
+}

--- a/client/src/store/NodeListProvider.tsx
+++ b/client/src/store/NodeListProvider.tsx
@@ -1,5 +1,7 @@
+import useGroupSelect from "@/hooks/useGroupSelect";
 import useHistoryState from "@/hooks/useHistoryState";
 import { Node, NodeData, SelectedNode } from "@/types/Node";
+import Konva from "konva";
 import { createContext, ReactNode, useContext, useState } from "react";
 import { useSocketStore } from "./useSocketStore";
 
@@ -15,6 +17,9 @@ export type NodeListContextType = {
   selectNode: ({ nodeId, parentNodeId }: SelectedNode) => void;
   title: string;
   updateTitle: (title: string) => void;
+  groupSelect: (group: Konva.Group[]) => void;
+  groupRelease: () => void;
+  selectedGroup: string[];
   loading: boolean;
 };
 
@@ -50,6 +55,7 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
   socket?.on("updateNode", (updatedNodeData) => {
     overrideNodeData(updatedNodeData);
   });
+  const { selectedGroup, groupRelease, groupSelect } = useGroupSelect();
 
   function updateNode(id: number, updatedNode: Partial<Node>) {
     setData((prevData) => ({
@@ -99,6 +105,9 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
         history,
         title,
         updateTitle,
+        groupSelect,
+        groupRelease,
+        selectedGroup,
         loading,
       }}
     >

--- a/client/src/types/Node.ts
+++ b/client/src/types/Node.ts
@@ -1,4 +1,6 @@
 import { Location } from "@/konva_mindmap/types/location";
+import Konva from "konva";
+import { RefObject } from "react";
 
 export type Node = {
   id: number;
@@ -21,4 +23,6 @@ export type NodeProps = {
   parentNode?: Node;
   node: Node;
   depth: number;
+  parentRef?: RefObject<Konva.Group>;
+  dragmode: boolean;
 };


### PR DESCRIPTION
#105 사용자는 각 단축키를 통해 캔버스의 마인드맵을 조작할 수 있다.

`이전 PR(feature-3-15-fe) 머지 후 머지할 브랜치입니다`
## 작업 내용

- 사용자 커맨드 추가
```tsx
useWindowKeyEventListener("keydown", (e) => {
    e.preventDefault();
    if (e.metaKey || e.ctrlKey) {
      if (e.shiftKey && e.code) redo();
      switch (e.code) {
        case "KeyZ":
          undo();
          break;
        case "KeyR":
          const url = window.location;
          location.href = url.pathname;
          break;
      }
    }

    switch (e.code) {
      case "Space":
        setDragMode(true);
        break;
      case "Backspace":
        deleteSelectedNodes();
        break;
      case "Equal":
        showNewNode(data, selectedNode, overrideNodeData);
        break;
      default:
        break;
    }
  });
```
  - switch/case 문을 통해 커맨드가 필요한 명령어 / 일반 키 명령어 / ctrl + shift + z -> redo처럼 세 개의 커맨드가 필요한 명령어에 대해서 분기처리를 시켜주었습니다.
  - backspace를 통해 삭제를 할 수 있도록 하여 이 경우에는 그룹으로 선택한 요소들에 대해서 삭제 처리를 해주어야 하기 때문에 deleteNode 함수에서 배열도 받을 수 있도록 리팩토링 하였습니다.
- 기존 textinput이나 textarea 등에서 이벤트 버블링 때문에 keydown 이벤트가 제대로 먹히지 않는 문제에 대해서 `e.stopPropagation` 처리를 통해 이벤트 전파를 막아 해결하였습니다.
