### PR TITLE
[Feature-3-6-fix-fe] 노드 추가 Input창 포커싱 관련 문제

### DIFF
--- a/client/src/components/Dashboard/UserDashBoard.tsx
+++ b/client/src/components/Dashboard/UserDashBoard.tsx
@@ -3,6 +3,9 @@ import addIcon from "@/assets/whitePlus.png";
 import searchIcon from "@/assets/search.png";
 import { Button, Input } from "@headlessui/react";
 import { useState } from "react";
+import { FaPlus } from "react-icons/fa";
+import { useNavigate } from "react-router-dom";
+import { useSocketStore } from "@/store/useSocketStore";
 
 const apiData = {
   mindMaps: [
@@ -120,6 +123,8 @@ const apiData = {
 export default function UserDashBoard() {
   const [data, setData] = useState(apiData.mindMaps);
   const [searchContent, setSearchContent] = useState("");
+  const navigate = useNavigate();
+  const handleConnection = useSocketStore((state) => state.handleConnection);
   localStorage.setItem("user", "강민주");
 
   function handleDeleteData(id: number) {
@@ -152,9 +157,9 @@ export default function UserDashBoard() {
       <div className="absolute bottom-8 right-8">
         <Button
           className="flex items-center justify-center gap-2 rounded-xl bg-bm-blue px-5 py-3"
-          onClick={() => console.log("마인드 맵 추가")}
+          onClick={() => handleConnection(navigate, "textupload")}
         >
-          <img className="h-4 w-4" src={addIcon} alt="마인드 맵 추가 버튼" />
+          <FaPlus className="h-4 w-4" />
           <p>새로운 마인드맵 만들기</p>
         </Button>
       </div>

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -30,10 +30,9 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
     selectedNode,
   } = useNodeListContext();
   const { dimensions, targetRef, handleWheel, zoomIn, zoomOut } = useDimension(data);
-  const { registerStageRef } = useStageStore();
   const registerLayer = useCollisionDetection(data, updateNode);
-  const stageRef = useRef<Konva.Stage>(null);
-  const [isDragMode, setDragMode] = useState(false);
+  const stageRef = useRef();
+  const { registerStageRef } = useStageStore();
   const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
 
   const rootKey = findRootNodeKey(data);

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -9,7 +9,6 @@ import { useEffect, useRef, useState } from "react";
 import { useStageStore } from "@/store/useStageStore";
 import NoNodeInform from "@/components/MindMapCanvas/NoNodeInform";
 import CanvasButtons from "@/components/MindMapCanvas/CanvasButtons";
-import Konva from "konva";
 import SelectionRect from "@/konva_mindmap/components/selectionRect";
 import DrawMindMap from "@/konva_mindmap/components/DrawMindMap";
 import ShowShortCut from "./ShowShortCut";
@@ -30,8 +29,8 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
     deleteSelectedNodes,
     selectedNode,
   } = useNodeListContext();
-  const { dimensions, targetRef, handleWheel, zoomIn, zoomOut } = useDimension(data);
   const [isDragMode, setDragMode] = useState(false);
+  const { dimensions, targetRef, handleWheel, zoomIn, zoomOut } = useDimension(data);
   const registerLayer = useCollisionDetection(data, updateNode);
   const stageRef = useRef();
   const { registerStageRef } = useStageStore();

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -65,7 +65,7 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
           break;
         case "KeyR":
           const url = window.location;
-          location.href = url.pathname;
+          location.href = url.pathname + url.search;
           break;
       }
     }

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -26,10 +26,12 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
     overrideNodeData,
     saveHistory,
     loading,
+    selectedGroup,
     deleteSelectedNodes,
     selectedNode,
   } = useNodeListContext();
   const { dimensions, targetRef, handleWheel, zoomIn, zoomOut } = useDimension(data);
+  const [isDragMode, setDragMode] = useState(false);
   const registerLayer = useCollisionDetection(data, updateNode);
   const stageRef = useRef();
   const { registerStageRef } = useStageStore();

--- a/client/src/components/MindMapMainSection/ControlSection/ListView/NodeItem.tsx
+++ b/client/src/components/MindMapMainSection/ControlSection/ListView/NodeItem.tsx
@@ -40,7 +40,6 @@ export default function NodeItem({ node, parentNodeId, open, handleAccordion, op
   useEffect(() => {
     if (node.newNode) {
       setIsEditing(true);
-      inputRef.current?.focus();
     }
   }, [node.id, setIsEditing]);
 
@@ -60,8 +59,8 @@ export default function NodeItem({ node, parentNodeId, open, handleAccordion, op
 
   function handleAddButton() {
     saveHistory(JSON.stringify(data));
-    selectNode({ nodeId: node.id, parentNodeId: parentNodeId });
-    showNewNode(data, { nodeId: node.id, parentNodeId: parentNodeId }, overrideNodeData);
+    selectNode({ nodeId: node.id, parentNodeId: parentNodeId, addTo: "list" });
+    showNewNode(data, { nodeId: node.id, parentNodeId: parentNodeId, addTo: "list" }, overrideNodeData);
     openAccordion();
   }
 
@@ -92,13 +91,13 @@ export default function NodeItem({ node, parentNodeId, open, handleAccordion, op
         )}
         {isEditing ? (
           <Input
+            autoFocus={selectedNode.addTo === "list"}
             ref={inputRef}
             className="flex-grow bg-transparent text-grayscale-200"
             value={keyword}
             onChange={handleChangeKeyword}
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}
-            autoFocus
             maxLength={30}
           />
         ) : (

--- a/client/src/components/MindMapMainSection/ControlSection/index.tsx
+++ b/client/src/components/MindMapMainSection/ControlSection/index.tsx
@@ -14,7 +14,7 @@ export default function ControlSection() {
   return (
     <section className="relative w-full min-w-80 max-w-[420px] flex-grow rounded-[20px] bg-grayscale-700">
       <div className="no-scrollbar absolute left-0 top-0 box-border h-full w-full overflow-y-scroll p-8">
-        {modeView[mode]}
+        {modeView[mode] || modeView.listview}
       </div>
     </section>
   );

--- a/client/src/components/MindMapMainSection/index.tsx
+++ b/client/src/components/MindMapMainSection/index.tsx
@@ -24,13 +24,11 @@ export default function MindMapMainSection() {
     };
   }, [mindMapId, connectSocket, disconnectSocket]);
 
-  if (!modeView[mode]) return <NotFound />;
-
   return (
     <>
       <MindMapHeader />
       <main className="flex h-[90%] w-full flex-col overflow-hidden p-8">
-        <p className="p-3 text-2xl font-bold">{modeView[mode]}</p>
+        <p className="p-3 text-2xl font-bold">{modeView[mode] || modeView.listview}</p>
         <div className="relative flex h-[90%] w-full gap-4">
           <MindMapView />
         </div>

--- a/client/src/konva_mindmap/components/EditableText.tsx
+++ b/client/src/konva_mindmap/components/EditableText.tsx
@@ -67,6 +67,7 @@ export default function EditableText({
     <>
       {isEditing ? (
         <EditableTextInput
+          focus={true}
           value={keyword}
           onChange={handleTextChange}
           onKeyDown={handleKeyDown}

--- a/client/src/konva_mindmap/components/EditableTextInput.tsx
+++ b/client/src/konva_mindmap/components/EditableTextInput.tsx
@@ -8,6 +8,7 @@ interface EditableTextInputProps {
   offsetX: number;
   offsetY: number;
   width: number;
+  focus: boolean;
 }
 
 export default function EditableTextInput({
@@ -18,11 +19,12 @@ export default function EditableTextInput({
   offsetX,
   offsetY,
   width,
+  focus,
 }: EditableTextInputProps) {
   return (
     <Html groupProps={{ offset: { x: offsetX, y: offsetY } }}>
       <input
-        autoFocus={true}
+        autoFocus={focus}
         value={value}
         onChange={onChange}
         className={`w-full resize-none bg-transparent text-center text-sm font-semibold text-black ${value.trim() === "" ? "border border-red-500" : ""}`}

--- a/client/src/konva_mindmap/components/MindMapNode.tsx
+++ b/client/src/konva_mindmap/components/MindMapNode.tsx
@@ -38,10 +38,10 @@ export default function MindMapNode({ data, parentNode, node, depth, parentRef, 
   function handleClick(e) {
     e.evt.preventDefault();
     if (selectedNode.nodeId === node.id) {
-      selectNode({ nodeId: 0, parentNodeId: 0 });
+      selectNode({ nodeId: 0, parentNodeId: 0, addTo: "canvas" });
       return;
     }
-    selectNode({ nodeId: node.id, parentNodeId: parentNode ? parentNode.id : null });
+    selectNode({ nodeId: node.id, parentNodeId: parentNode ? parentNode.id : null, addTo: "canvas" });
   }
 
   const NodeStroke = selectedGroup.includes(node.id.toString()) ? "red" : "";

--- a/client/src/konva_mindmap/components/MindMapNode.tsx
+++ b/client/src/konva_mindmap/components/MindMapNode.tsx
@@ -17,6 +17,7 @@ export default function MindMapNode({ data, parentNode, node, depth, parentRef, 
   const { saveHistory, updateNode, selectNode, selectedNode, selectedGroup, overrideNodeData } = useNodeListContext();
   const [isEditing, setIsEditing] = useState(false);
   const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
+  const socket = useSocketStore.getState().socket;
 
   function handleDoubleClick() {
     setIsEditing(true);

--- a/client/src/konva_mindmap/components/NewNode.tsx
+++ b/client/src/konva_mindmap/components/NewNode.tsx
@@ -53,6 +53,7 @@ export default function NewNode({ data, node, depth }: NodeProps) {
         shadowBlur={5}
       />
       <EditableTextInput
+        focus={selectedNode.addTo === "canvas"}
         value={keyword}
         offsetX={70 - depth * 10}
         offsetY={8 * depth - 60}

--- a/client/src/store/NodeListProvider.tsx
+++ b/client/src/store/NodeListProvider.tsx
@@ -9,14 +9,14 @@ import { deleteNodes } from "@/konva_mindmap/events/deleteNode";
 
 export type NodeListContextType = {
   data: NodeData | null;
-  selectedNode: { nodeId: number; parentNodeId: number } | null;
+  selectedNode: SelectedNode | null;
   history: string[];
   updateNode: (id: number, node: Partial<Node>) => void;
   overrideNodeData: (node: NodeData | ((newData: NodeData) => void)) => void;
   saveHistory: (newState: string) => void;
   undoData: () => void;
   redoData: () => void;
-  selectNode: ({ nodeId, parentNodeId }: SelectedNode) => void;
+  selectNode: ({ nodeId, parentNodeId, addTo }: SelectedNode) => void;
   title: string;
   updateTitle: (title: string) => void;
   groupSelect: (group: Konva.Group[]) => void;
@@ -39,7 +39,7 @@ export function useNodeListContext() {
 
 export default function NodeListProvider({ children }: { children: ReactNode }) {
   const [data, setData] = useState({});
-  const [selectedNode, setSelectedNode] = useState({ nodeId: 0, parentNodeId: 0 });
+  const [selectedNode, setSelectedNode] = useState<SelectedNode>({ nodeId: 0, parentNodeId: 0, addTo: "canvas" });
   const { saveHistory, overrideHistory, undo, redo, history } = useHistoryState<NodeData>(JSON.stringify(data));
   const [title, setTitle] = useState(mindMapInfo.title);
   const [loading, setLoading] = useState(true);
@@ -83,14 +83,15 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
     redo(setData);
   }
 
-  function selectNode({ nodeId, parentNodeId }: SelectedNode) {
+  function selectNode({ nodeId, parentNodeId, addTo }: SelectedNode) {
     if (!nodeId) {
-      setSelectedNode({ nodeId: 0, parentNodeId: 0 });
+      setSelectedNode({ nodeId: 0, parentNodeId: 0, addTo: addTo });
       return;
     }
     setSelectedNode({
       nodeId,
       parentNodeId,
+      addTo,
     });
   }
 

--- a/client/src/types/Node.ts
+++ b/client/src/types/Node.ts
@@ -16,6 +16,7 @@ export type NodeData = Record<number, Node>;
 export type SelectedNode = {
   nodeId: number;
   parentNodeId: number;
+  addTo: "canvas" | "list";
 };
 
 export type NodeProps = {


### PR DESCRIPTION
## 작업 내용
노드 추가 Input창이 포커싱이 리스트 뷰에서만 포커싱이 되는 문제를 해결했습니다.
문제의 원인은 리스트 뷰와 캔버스 모두에서 각각 autofocusing을 준 데다가, 리스트 뷰의 경우 useEffect ref까지 걸어 focus를 통해 포커싱을 유도하여 마인드맵에서 노드를 추가해도 포커싱이 리스트 뷰로 옮겨갔습니다
이를 해결하기 위해 각 노드를 선택하고 추가할 때, 어떤 항목에서 노드가 추가되는지를 상태에 기록하고 이에 따라 포커싱을 줄 수 있도록 수정했습니다.