### PR TITLE
[feature-3-7-fix-fe] 노드 수정시 원래 content와 동일할 경우 요청 전송 방지

### DIFF
--- a/client/src/hooks/useNodeActions.ts
+++ b/client/src/hooks/useNodeActions.ts
@@ -13,7 +13,7 @@ export default function useNodeActions(nodeId: number, content: string) {
 
   useEffect(() => {
     setKeyword(content);
-  }, [nodeId]);
+  }, [content]);
 
   const originalContent = content;
 

--- a/client/src/hooks/useNodeActions.ts
+++ b/client/src/hooks/useNodeActions.ts
@@ -18,7 +18,7 @@ export default function useNodeActions(nodeId: number, content: string) {
   const originalContent = content;
 
   function saveContent() {
-    if (keyword.trim()) {
+    if (keyword.trim() && keyword !== originalContent) {
       handleSocketEvent({
         actionType: "updateNode",
         payload: { ...data, [nodeId]: { ...data[nodeId], keyword: keyword, newNode: false } },
@@ -53,7 +53,7 @@ export default function useNodeActions(nodeId: number, content: string) {
 
   function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
     e.stopPropagation();
-    if (e.key == "Enter" && !e.nativeEvent.isComposing) setIsEditing(false);
+    if (e.key == "Enter" && !e.nativeEvent.isComposing) saveContent();
   }
 
   function handleDelete() {

--- a/client/src/konva_mindmap/components/EditableText.tsx
+++ b/client/src/konva_mindmap/components/EditableText.tsx
@@ -1,5 +1,5 @@
 import { Text } from "react-konva";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import EditableTextInput from "@/konva_mindmap/components/EditableTextInput";
 import { useSocketStore } from "@/store/useSocketStore";
@@ -29,12 +29,16 @@ export default function EditableText({
   const { data, updateNode, saveHistory } = useNodeListContext();
   const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
 
+  useEffect(() => {
+    setKeyword(text);
+  }, [text]);
+
   function handleTextChange(e: React.ChangeEvent<HTMLInputElement>) {
     setKeyword(e.target.value);
   }
 
   function saveContent() {
-    if (keyword.trim()) {
+    if (keyword.trim() && keyword !== originalContent) {
       handleSocketEvent({
         actionType: "updateNode",
         payload: { ...data, [id]: { ...data[id], keyword: keyword } },


### PR DESCRIPTION
## 작업 내용
- 화면상 동기화를 위한 `editableText`의 `useEffect` 롤백

- 노드 수정시 원래 content와 내용이 동일할 경우 요청 전송 방지

https://github.com/user-attachments/assets/33644db3-49ab-4396-893c-660b34cda74a

## 논의하고 싶은 내용


