### PR TITLE
[Feature-6-1,2-fe] 유저는 기존에 생성했던 마인드맵 히스토리를 눌러 해당 마인드맵 캔버스로 이동할 수 있다.

### DIFF
--- a/client/src/api/dashboard.api.ts
+++ b/client/src/api/dashboard.api.ts
@@ -1,0 +1,7 @@
+import { instance } from "@/api";
+import { DashBoard } from "@/konva_mindmap/types/dashboard";
+
+export async function getDashBoard(): Promise<DashBoard[]> {
+  const { data } = await instance.get("/dashboard");
+  return data;
+}

--- a/client/src/api/fetchHooks/useDashBoard.ts
+++ b/client/src/api/fetchHooks/useDashBoard.ts
@@ -1,0 +1,6 @@
+import { getDashBoard } from "@/api/dashboard.api";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+export default function useDashBoard() {
+  return useSuspenseQuery({ queryKey: ["dashboard"], queryFn: getDashBoard, retry: 2, refetchOnMount: true });
+}

--- a/client/src/api/fetchHooks/useDeleteMindMap.ts
+++ b/client/src/api/fetchHooks/useDeleteMindMap.ts
@@ -1,0 +1,12 @@
+import { deleteMindMap } from "@/api/mindmap.api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function useDeleteMindMap({ mindMapId, onError }) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => deleteMindMap(mindMapId),
+    mutationKey: ["dashboard"],
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["dashboard"] }),
+    onError,
+  });
+}

--- a/client/src/api/mindmap.api.ts
+++ b/client/src/api/mindmap.api.ts
@@ -1,5 +1,9 @@
 import { instance } from "@/api";
 
-export async function createMindmap() {
+export function createMindmap() {
   return instance.post("/connection");
+}
+
+export function deleteMindMap(mindMapId: string) {
+  return instance.delete(`/mindmap/${mindMapId}`);
 }

--- a/client/src/components/Dashboard/MindMapInfoItem.tsx
+++ b/client/src/components/Dashboard/MindMapInfoItem.tsx
@@ -1,41 +1,45 @@
 import profile from "@/assets/profile.png";
-import deleteIcon from "@/assets/trash2.png";
 import useModal from "@/hooks/useModal";
 import { Button } from "@headlessui/react";
 import extractDate from "@/utils/extractDate";
 import DeleteMindMapModal from "../DeleteMindMapModal";
 import { createPortal } from "react-dom";
+import { useAuthStore } from "@/store/useAuthStore";
+import { FaRegTrashAlt } from "react-icons/fa";
+import { useNavigate } from "react-router-dom";
+import { useDeleteMindMap } from "@/api/fetchHooks/useDeleteMindMap";
+import { DashBoard } from "@/konva_mindmap/types/dashboard";
 
 interface MindMapInfoItemProps {
-  data: {
-    id: number;
-    connectionId: string;
-    title: string;
-    keyword: string[];
-    createdDate: Date;
-    modifiedDate: Date;
-    owner: string;
-  };
+  data: DashBoard;
   index: number;
-  handleDeleteData: (id: number) => void;
 }
 
-export default function MindMapInfoItem({ data, index, handleDeleteData }: MindMapInfoItemProps) {
+export default function MindMapInfoItem({ data, index }: MindMapInfoItemProps) {
   const { open, openModal, closeModal } = useModal();
-
+  const { name } = useAuthStore();
   const keywordData = data.keyword.slice(0, 4);
+  const navigate = useNavigate();
+  const mutation = useDeleteMindMap({
+    mindMapId: data.id.toString(),
+    onError: (error) => console.log(error),
+  });
 
-  const ownerCheck = localStorage.getItem("user") === data.owner;
+  const ownerCheck = name === data.owner;
 
-  const confirmDelete = () => {
-    handleDeleteData(data.id);
+  function handleDelete() {
+    mutation.mutate();
     closeModal();
-  };
+  }
+  function navigateToMindMap() {
+    navigate(`/mindmap/${data.connectionId}?mode=listview`);
+  }
 
   return (
     <>
       <div
-        className={`${index !== 0 ? "border-t-[1px] border-t-grayscale-500" : ""} flex items-center justify-between px-3 py-2`}
+        className={`${index !== 0 ? "border-t-[1px] border-t-grayscale-500" : ""} flex cursor-pointer items-center justify-between px-3 py-2`}
+        onClick={navigateToMindMap}
       >
         <div className="min-w-72">{data.title}</div>
         <div className="grid w-60 grid-cols-2 gap-1 px-5 text-xs">
@@ -53,14 +57,16 @@ export default function MindMapInfoItem({ data, index, handleDeleteData }: MindM
           <div>{data.owner}</div>
         </div>
         <div className="flex min-w-40 justify-between">
-          <div>{extractDate(data.createdDate)}</div>
+          <div>{extractDate(new Date(data.createDate))}</div>
           {ownerCheck ? (
-            <Button className="group" onClick={openModal}>
-              <img
-                className="h-6 w-6 group-hover:brightness-0 group-hover:invert"
-                src={deleteIcon}
-                alt="마인드 맵 삭제 버튼"
-              />
+            <Button
+              className="group"
+              onClick={(e) => {
+                e.stopPropagation();
+                openModal();
+              }}
+            >
+              <FaRegTrashAlt className="h-5 w-5 fill-grayscale-500 group-hover:fill-slate-400" />
             </Button>
           ) : (
             <></>
@@ -68,7 +74,7 @@ export default function MindMapInfoItem({ data, index, handleDeleteData }: MindM
         </div>
       </div>
       {createPortal(
-        <DeleteMindMapModal open={open} closeModal={closeModal} confirmDelete={confirmDelete} data={data} />,
+        <DeleteMindMapModal open={open} closeModal={closeModal} confirmDelete={handleDelete} data={data} />,
         document.body,
       )}
     </>

--- a/client/src/components/Dashboard/NoMindMap.tsx
+++ b/client/src/components/Dashboard/NoMindMap.tsx
@@ -1,0 +1,26 @@
+import { useAuthStore } from "@/store/useAuthStore";
+import { useSocketStore } from "@/store/useSocketStore";
+import { Button } from "@headlessui/react";
+import { FaPlus } from "react-icons/fa";
+import { useNavigate } from "react-router-dom";
+import cloud from "@/assets/dashbordIcon.png";
+
+export default function NoMindMap() {
+  const handleConnection = useSocketStore((state) => state.handleConnection);
+  const navigate = useNavigate();
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  return (
+    <div className="relative flex h-full w-full flex-col items-center justify-center gap-5 rounded-[20px] bg-grayscale-700 px-8 pb-24 pt-8">
+      <img className="w-1/2" src={cloud} alt="" />
+      <p>현재 만들어둔 마인드맵이 없어요</p>
+      <p>새로운 마인드맵을 생성하고 브레인스토밍 해보세요!</p>
+      <Button
+        className="flex items-center justify-center gap-2 rounded-xl bg-bm-blue px-5 py-3"
+        onClick={() => handleConnection(navigate, "textupload", isAuthenticated)}
+      >
+        <FaPlus className="h-4 w-4" />
+        <p>새로운 마인드맵 만들기</p>
+      </Button>
+    </div>
+  );
+}

--- a/client/src/components/Dashboard/UserDashBoard.tsx
+++ b/client/src/components/Dashboard/UserDashBoard.tsx
@@ -7,140 +7,24 @@ import { FaPlus } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import { useSocketStore } from "@/store/useSocketStore";
 import { useAuthStore } from "@/store/useAuthStore";
-
-const apiData = {
-  mindMaps: [
-    {
-      id: 1,
-      connectionId: "asdf12-asd1f8-asd1f5-asdf",
-      title: "점심 메뉴를 골라볼까나~?",
-      keyword: ["점심메뉴", "한식", "중식", "양식", "일식", "피자", "초밥"],
-      createdDate: new Date(),
-      modifiedDate: new Date(),
-      owner: "강민주",
-    },
-    {
-      id: 2,
-      connectionId: "asdf12-asd1f8-asd1f5-asdf",
-      title: "이번 주 주말에 뭐할까?",
-      keyword: ["주말에 갈 곳", "놀이공원", "더현대 서울", "카페", "쇼핑", "놀이기구"],
-      createdDate: new Date(),
-      modifiedDate: new Date(),
-      owner: "양현호",
-    },
-    {
-      id: 3,
-      connectionId: "asdf12-asd1f8-asd1f5-asdf",
-      title: "여행",
-      keyword: ["여행", "국내", "국외", "부산", "제주도", "여수", "일본", "베트남", "미국"],
-      createdDate: new Date(),
-      modifiedDate: new Date(),
-      owner: "조민형",
-    },
-    {
-      id: 4,
-      connectionId: "asdf12-asd1f8-asd1f5-asdf",
-      title: "프로젝트 회의",
-      keyword: ["회의", "에러 발생!!", "추가 기능", "진행상황공유", "UI 에러..."],
-      createdDate: new Date(),
-      modifiedDate: new Date(),
-      owner: "김남희",
-    },
-    {
-      id: 5,
-      connectionId: "asdf12-asd1f8-asd1f5-asdf",
-      title: "점심 메뉴를 골라볼까나~?",
-      keyword: ["점심메뉴", "한식", "중식", "양식", "일식", "피자", "초밥"],
-      createdDate: new Date(),
-      modifiedDate: new Date(),
-      owner: "강민주",
-    },
-    {
-      id: 6,
-      connectionId: "asdf12-asd1f8-asd1f5-asdf",
-      title: "이번 주 주말에 뭐할까?",
-      keyword: ["주말에 갈 곳", "놀이공원", "더현대 서울", "카페", "쇼핑", "놀이기구"],
-      createdDate: new Date(),
-      modifiedDate: new Date(),
-      owner: "양현호",
-    },
-    {
-      id: 7,
-      connectionId: "asdf12-asd1f8-asd1f5-asdf",
-      title: "여행",
-      keyword: ["여행", "국내", "국외", "부산", "제주도", "여수", "일본", "베트남", "미국"],
-      createdDate: new Date(),
-      modifiedDate: new Date(),
-      owner: "조민형",
-    },
-    {
-      id: 8,
-      connectionId: "asdf12-asd1f8-asd1f5-asdf",
-      title: "프로젝트 회의",
-      keyword: ["회의", "에러 발생!!", "추가 기능", "진행상황공유", "UI 에러..."],
-      createdDate: new Date(),
-      modifiedDate: new Date(),
-      owner: "김남희",
-    },
-    {
-      id: 9,
-      connectionId: "asdf12-asd1f8-asd1f5-asdf",
-      title: "점심 메뉴를 골라볼까나~?",
-      keyword: ["점심메뉴", "한식", "중식", "양식", "일식", "피자", "초밥"],
-      createdDate: new Date(),
-      modifiedDate: new Date(),
-      owner: "강민주",
-    },
-    {
-      id: 10,
-      connectionId: "asdf12-asd1f8-asd1f5-asdf",
-      title: "이번 주 주말에 뭐할까?",
-      keyword: ["주말에 갈 곳", "놀이공원", "더현대 서울", "카페", "쇼핑", "놀이기구"],
-      createdDate: new Date(),
-      modifiedDate: new Date(),
-      owner: "양현호",
-    },
-    {
-      id: 11,
-      connectionId: "asdf12-asd1f8-asd1f5-asdf",
-      title: "여행",
-      keyword: ["여행", "국내", "국외", "부산", "제주도", "여수", "일본", "베트남", "미국"],
-      createdDate: new Date(),
-      modifiedDate: new Date(),
-      owner: "조민형",
-    },
-    {
-      id: 12,
-      connectionId: "asdf12-asd1f8-asd1f5-asdf",
-      title: "프로젝트 회의",
-      keyword: ["회의", "에러 발생!!", "추가 기능", "진행상황공유", "UI 에러..."],
-      createdDate: new Date(),
-      modifiedDate: new Date(),
-      owner: "김남희",
-    },
-  ],
-};
+import useDashBoard from "@/api/fetchHooks/useDashBoard";
+import NoMindMap from "@/components/Dashboard/NoMindMap";
 
 export default function UserDashBoard() {
-  const [data, setData] = useState(apiData.mindMaps);
+  const { data } = useDashBoard();
   const [searchContent, setSearchContent] = useState("");
   const navigate = useNavigate();
   const handleConnection = useSocketStore((state) => state.handleConnection);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
-  function handleDeleteData(id: number) {
-    const newData = data.filter((item) => item.id !== id);
-    setData(newData);
-  }
-
   function searchData(content: string) {
-    const filteredData = data.filter(
-      (item) => item.title.includes(content) || item.keyword.some((k) => k.includes(content)),
-    );
-    return filteredData;
+    if (!data) return [];
+    return data.filter((item) => item.title.includes(content) || item.keyword.some((k) => k.includes(content)));
   }
 
   const filteredData = searchData(searchContent);
+
+  if (!data.length) return <NoMindMap />;
 
   return (
     <div className="relative flex h-full w-full flex-col rounded-[20px] bg-grayscale-700 px-8 pb-24 pt-8">
@@ -152,7 +36,7 @@ export default function UserDashBoard() {
       </header>
       <div className="no-scrollbar h-[calc(100%-40px)] overflow-y-scroll border-b-[1px] border-t-[1px] border-grayscale-500">
         {filteredData.map((info, i) => (
-          <MindMapInfoItem key={i} data={info} index={i} handleDeleteData={handleDeleteData} />
+          <MindMapInfoItem key={i} data={info} index={i} />
         ))}
       </div>
       <div className="absolute bottom-8 right-8">
@@ -172,7 +56,7 @@ export default function UserDashBoard() {
           }}
           placeholder="키워드나 제목을 입력하세요"
         />
-        <Button onClick={() => searchData(searchContent)}>
+        <Button>
           <img className="h-6 w-6" src={searchIcon} alt="검색하기 버튼" />
         </Button>
       </div>

--- a/client/src/components/MindMapHeader/index.tsx
+++ b/client/src/components/MindMapHeader/index.tsx
@@ -3,19 +3,26 @@ import Profile from "@/components/MindMapHeader/Profile";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { Input } from "@headlessui/react";
 import { useState } from "react";
-import { RiMindMap } from "react-icons/ri";
+import { FaPencilAlt } from "react-icons/fa";
 
 export default function MindMapHeader() {
-  const { title, updateTitle } = useNodeListContext();
+  const { title, updateTitle, isOwner } = useNodeListContext();
   const [editMode, setEditMode] = useState(false);
 
   function handleInputBlur() {
+    if (!title.length) return;
     setEditMode(false);
   }
+
+  function changeToEditMode() {
+    if (!isOwner) return;
+    setEditMode(true);
+  }
+
   function handleInputKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     e.stopPropagation();
     if (e.key === "Enter") {
-      setEditMode(false);
+      handleInputBlur();
     }
   }
 
@@ -24,17 +31,17 @@ export default function MindMapHeader() {
       <MindMapHeaderButtons />
       {editMode ? (
         <Input
-          className="flex items-center bg-transparent text-center"
+          className="flex w-80 items-center bg-transparent text-center"
           value={title}
           onChange={(e) => updateTitle(e.target.value)}
           onBlur={handleInputBlur}
           onKeyDown={handleInputKeyDown}
-          autoFocus
+          maxLength={32}
         />
       ) : (
-        <span onDoubleClick={() => setEditMode(true)} className="flex cursor-pointer items-center gap-3 text-lg">
-          <RiMindMap className="h-5 w-5" />
+        <span onDoubleClick={changeToEditMode} className="flex cursor-pointer items-center gap-3 text-lg">
           {title}
+          <FaPencilAlt onClick={changeToEditMode} />
         </span>
       )}
       <Profile />

--- a/client/src/components/Minutes/Tiptap/index.tsx
+++ b/client/src/components/Minutes/Tiptap/index.tsx
@@ -9,8 +9,10 @@ import MenuBar from "./MenuBar";
 import { Indent } from "./utils/indent";
 import CustomCodeBlockLowlight from "./utils/codeBlockIndent";
 import Placeholder from "@tiptap/extension-placeholder";
+import { useNodeListContext } from "@/store/NodeListProvider";
 
 export default function Tiptap({ text, setText }) {
+  const { isOwner } = useNodeListContext();
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -30,6 +32,7 @@ export default function Tiptap({ text, setText }) {
     ],
     content: text,
     onUpdate({ editor }) {
+      if (!isOwner) return;
       setText(editor.getHTML());
     },
   });

--- a/client/src/konva_mindmap/types/dashboard.ts
+++ b/client/src/konva_mindmap/types/dashboard.ts
@@ -1,0 +1,9 @@
+export type DashBoard = {
+  id: number;
+  connectionId: string;
+  title: string;
+  keyword: string[];
+  createDate: Date;
+  modifiedDate: Date;
+  owner: string;
+};


### PR DESCRIPTION
# 유저 대시보드 관련 PR입니다.

이슈번호 : #21 #23 #26 

## 작업 내용
- 대시보드에서 대시보드 가져오는 api와 이를 호출하여 데이터를 가져오거나 mutate하는 쿼리 훅을 추가했습니다.
  - 쿼리 훅같은 경우 기존에 사용하는 훅들보다 사용할 수 있는 환경이 한정적인 점을 고려하여 api에 추가적으로 fetchHooks라는 디렉토리를 만들어 따로 보관하였습니다.
```tsx
export function useDeleteMindMap({ mindMapId, onError }) {
  const queryClient = useQueryClient();
  return useMutation({
    mutationFn: () => deleteMindMap(mindMapId),
    mutationKey: ["dashboard"],
    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["dashboard"] }),
    onError,
  });
}
```
  - useMutation 훅의 경우는 기존의 API를 사용해서 CRUD 중 CUD들에 대한 작업을 주로 수행하는데, 요청이 완료되면 queryclient에서 기존에 가지고 있던 캐시를 비활성화시키면서 다시금 fetch가 이루어질 수 있도록 하였습니다.
  - 에러의 경우 훅을 사용하는 컴포넌트 내부에서 사용할 수 있도록 하였습니다.
- 대시보드가 없을 때 띄울 화면을 추가했습니다.
![image](https://github.com/user-attachments/assets/f4a7a589-956d-490d-a23e-1a6a9fa23739)
- 대시보드에서 마인드맵을 누르면 해당 마인드맵으로 navigate하여 연결될 수 있도록 하였습니다.
- 그 밖에 추가적인 사항으로 비회원 유저의 경우 제목 수정을 막아놓는 기능을 추가했습니다.
 
## 논의하고 싶은 내용
```tsx
const mutation = useDeleteMindMap({
    mindMapId: data.id.toString(),
    onError: (error) => console.log(error),
  });
```
현재는 에러에 대해 따로 처리해주지 않았는데, 이에 대해 ui 논의를 다시금 해보면 좋을 것 같습니당
