### PR TITLE
[Feature-6-10-fe]대시보드에 있을 때, 기존 작업 내역이 있는 경우 사이드바의 다른 버튼들을 누르면 최근 방문했던 마인드맵으로 돌아가기와 새로운 마인드맵 누르기 버튼이 모달로 생기며 두 가지 선택지를 통해 마인드맵에 접근할 수 있다.

### DIFF
--- a/client/src/components/Dashboard/MindMapInfoItem.tsx
+++ b/client/src/components/Dashboard/MindMapInfoItem.tsx
@@ -38,7 +38,7 @@ export default function MindMapInfoItem({ data, index }: MindMapInfoItemProps) {
   return (
     <>
       <div
-        className={`${index !== 0 ? "border-t-[1px] border-t-grayscale-500" : ""} flex cursor-pointer items-center justify-between px-3 py-2`}
+        className={`${index !== 0 ? "border-t-[1px] border-t-grayscale-500" : ""} flex h-16 cursor-pointer items-center justify-between px-3 py-2`}
         onClick={navigateToMindMap}
       >
         <div className="min-w-72">{data.title}</div>

--- a/client/src/components/Sidebar/LatestMindMapModal.tsx
+++ b/client/src/components/Sidebar/LatestMindMapModal.tsx
@@ -1,0 +1,26 @@
+import Modal from "@/components/common/Modal";
+import { Button } from "@headlessui/react";
+
+export default function LatestMindMapModal({ open, closeModal, navigateToLatestMindap, navigateToNewMindMap }) {
+  return (
+    <Modal open={open} closeModal={closeModal}>
+      <div className="flex w-full flex-col items-center justify-center gap-5 py-4 text-grayscale-700">
+        <p className="font-bold">최근에 작업했던 마인드맵이 있어요!</p>
+        <div className="flex w-full flex-col gap-3 text-sm">
+          <Button
+            className="w-full rounded-md bg-bm-purple p-2.5 text-black transition hover:brightness-90"
+            onClick={navigateToLatestMindap}
+          >
+            작업하던 마인드맵으로 돌아가기
+          </Button>
+          <Button
+            className="w-full rounded-md bg-bm-blue p-2.5 text-grayscale-100 transition hover:brightness-90"
+            onClick={navigateToNewMindMap}
+          >
+            새로운 마인드맵 만들기
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/client/src/store/NodeListProvider.tsx
+++ b/client/src/store/NodeListProvider.tsx
@@ -6,7 +6,7 @@ import { createContext, ReactNode, useContext, useState } from "react";
 
 import { useSocketStore } from "./useSocketStore";
 import { deleteNodes } from "@/konva_mindmap/events/deleteNode";
-import { checkOwner } from "@/utils/localstorage";
+import { checkOwner, setLatestMindMap } from "@/utils/localstorage";
 
 export type NodeListContextType = {
   data: NodeData | null;
@@ -68,6 +68,7 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
   socket?.on("disconnect", () => {
     setData({});
     overrideHistory(JSON.stringify({}));
+    setLatestMindMap(mindMapId);
   });
 
   function updateNode(id: number, updatedNode: Partial<Node>) {

--- a/client/src/utils/localstorage.ts
+++ b/client/src/utils/localstorage.ts
@@ -13,3 +13,11 @@ export const checkOwner = (mindMapId: string) => {
   if (!mindmaps) return false;
   return mindmaps.some((history) => history === mindMapId);
 };
+
+export const setLatestMindMap = (mindMapId: string) => {
+  localStorage.setItem("latest", mindMapId);
+};
+
+export const getLatestMindMap = () => {
+  return localStorage.getItem("latest");
+};


### PR DESCRIPTION
#130 대시보드에 있을 때, 기존 작업 내역이 있는 경우 사이드바의 다른 버튼들을 누르면 최근 방문했던 마인드맵으로 돌아가기와 새로운 마인드맵 누르기 버튼이 모달로 생기며 두 가지 선택지를 통해 마인드맵에 접근할 수 있다.

## 작업 내용
- 기존 작업을 하고 소켓 연결이 끊겼을 때, 로컬스토리지에 최근 마인드맵 정보를 저장하고 대시보드에서 다시 사이드바를 통해 마인드맵 생성을 누르면 최근 방문했던 마인드맵으로 돌아가기와 새로운 마인드맵 누르기 버튼을 가지는 모달이 켜지도록 했습니다.
<img width="1281" alt="스크린샷 2024-11-28 오전 2 04 03" src="https://github.com/user-attachments/assets/6b6f80b0-229c-4497-97ca-860c033795c1">
- 대시보드에서 키워드가 없을 때와 있을 때의 heigth가 차이가 나서 통일될 수 있도록 높이를 조정했습니다.

## 논의하고 싶은 내용
```tsx
  const navigateMindmap = (mode: "listview" | "voiceupload" | "textupload") => {
    if (socket) {
      handleViewMode(mode);
      return;
    }
    const latestMindMap = getLatestMindMap();
    if (!latestMindMap) {
      handleConnection(navigate, mode, isAuthenticated);
    }
    openModal();
  };

  function navigateToLatestMindap() {
    navigate(`/mindmap/${getLatestMindMap()}?mode=listview`);
    closeModal();
  }
  function navigateToNewMindMap() {
    handleConnection(navigate, "listview", isAuthenticated);
    closeModal();
  }
```
요 로직에서 모드도 넘겨주고 싶은데 로직상 쉽지 않네요.. 혹시 생각나는 방법 있으신분 조언 부탁드립니당

