### PR TITLE
[Feature-3-19-fe] 소유자는 헤더의 마인드맵 제목이나 회의록의 내용을 변경할 수 있으며, 변경 내용은 broadcast되어 동시 편집중인 모든 사람들에게 보인다.

### DIFF
--- a/client/src/components/Dashboard/GuestDashBoard.tsx
+++ b/client/src/components/Dashboard/GuestDashBoard.tsx
@@ -19,11 +19,10 @@ export default function GuestDashBoard() {
         </p>
         <img className="w-[300px]" src={dashboardIcon} alt="대쉬보드 아이콘" />
         <Button
-          className="group flex w-[300px] items-center justify-center gap-3 rounded-[10px] bg-grayscale-600 px-10 py-2 text-grayscale-200 hover:text-white"
-          onClick={openConfirmModal}
+          className="w-[300px] rounded-[10px] bg-grayscale-600 px-24 py-2 text-xl text-grayscale-200 hover:text-white"
+          onClick={openLoginModal}
         >
-          <img className="w-6 group-hover:brightness-0 group-hover:invert" src={plusIcon} alt="추가하기 아이콘" />
-          <p className="text-xl text-grayscale-200 group-hover:text-white">새로운 마인드맵 만들기</p>
+          로그인하기
         </Button>
         <GuestNewMindMapModal
           open={confirmModal}
@@ -34,10 +33,10 @@ export default function GuestDashBoard() {
           }}
         />
         <Button
-          className="mt-4 w-[300px] rounded-[10px] bg-grayscale-600 px-24 py-2 text-xl text-grayscale-200 hover:text-white"
-          onClick={openLoginModal}
+          className="group mt-4 flex w-[300px] items-center justify-center gap-3 rounded-[10px] bg-grayscale-600 px-10 py-2 text-grayscale-200 hover:text-white"
+          onClick={openConfirmModal}
         >
-          로그인하기
+          <p className="text-xl text-grayscale-200 group-hover:text-white">새로운 마인드맵 만들기</p>
         </Button>
       </div>
       <LoginModal open={loginModal} close={closeLoginModal} />

--- a/client/src/components/MindMapHeader/index.tsx
+++ b/client/src/components/MindMapHeader/index.tsx
@@ -1,16 +1,28 @@
+import Spinner from "@/components/common/Spinner";
 import MindMapHeaderButtons from "@/components/MindMapHeader/MindMapHeaderButtons";
 import Profile from "@/components/MindMapHeader/Profile";
+import useAuth from "@/hooks/useAuth";
 import { useNodeListContext } from "@/store/NodeListProvider";
+import { useSocketStore } from "@/store/useSocketStore";
 import { Input } from "@headlessui/react";
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { FaPencilAlt } from "react-icons/fa";
 
 export default function MindMapHeader() {
   const { title, updateTitle, isOwner } = useNodeListContext();
+  const { isLoading } = useAuth();
   const [editMode, setEditMode] = useState(false);
+  const handleSocketEvent = useSocketStore((state) => state.handleSocketEvent);
+  const [editTitle, setEditTitle] = useState(title);
 
   function handleInputBlur() {
     if (!title.length) return;
+    handleSocketEvent({
+      actionType: "updateTitle",
+      payload: { title: editTitle },
+      callback: (response) => updateTitle(response),
+    });
     setEditMode(false);
   }
 
@@ -32,8 +44,8 @@ export default function MindMapHeader() {
       {editMode ? (
         <Input
           className="flex w-80 items-center bg-transparent text-center"
-          value={title}
-          onChange={(e) => updateTitle(e.target.value)}
+          value={editTitle}
+          onChange={(e) => setEditTitle(e.target.value)}
           onBlur={handleInputBlur}
           onKeyDown={handleInputKeyDown}
           maxLength={32}
@@ -45,6 +57,7 @@ export default function MindMapHeader() {
         </span>
       )}
       <Profile />
+      {isLoading && createPortal(<Spinner />, document.body)}
     </header>
   );
 }

--- a/client/src/components/MindMapMainSection/ControlSection/ListView/NodeItem.tsx
+++ b/client/src/components/MindMapMainSection/ControlSection/ListView/NodeItem.tsx
@@ -1,15 +1,15 @@
-import arrowDown from "@/assets/arrowDown.png";
-import plusIcon from "@/assets/plus.png";
-import editIcon from "@/assets/pencil.png";
-import deleteIcon from "@/assets/trash2.png";
 import { Input } from "@headlessui/react";
-import useNodeActions from "@/hooks/useNodeActions";
-import bulletPointIcon from "@/assets/bulletPoint.png";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { showNewNode } from "@/konva_mindmap/events/addNode";
 import { useEffect, useRef } from "react";
 import { Node } from "@/types/Node";
 import { NODE_DEPTH_LIMIT } from "@/constants/node";
+import { TbPointFilled } from "react-icons/tb";
+import { FaChevronDown } from "react-icons/fa";
+import { FaPencilAlt } from "react-icons/fa";
+import { FaPlus } from "react-icons/fa";
+import { FaRegTrashAlt } from "react-icons/fa";
+import useNodeActions from "@/hooks/useNodeActions";
 
 type NodeItemProps = {
   node: Node;
@@ -73,16 +73,18 @@ export default function NodeItem({ node, parentNodeId, open, handleAccordion, op
       onMouseLeave={handleMouseLeave}
     >
       <div className="flex min-w-0 flex-1 items-center gap-3">
-        {node.depth < NODE_DEPTH_LIMIT ? (
-          <button
-            className={`flex h-5 w-5 items-center justify-center transition-all ${open ? "" : "rotate-[-90deg]"}`}
-            onClick={handleAccordion}
-          >
-            <img src={arrowDown} alt="열기" className="h-3 w-4" />
-          </button>
-        ) : (
-          <img src={bulletPointIcon} alt="구분점" className="h-2 w-2" />
-        )}
+        {!isEditing &&
+          (node.depth < NODE_DEPTH_LIMIT ? (
+            <button
+              className={`flex h-5 w-5 items-center justify-center transition-all ${open ? "" : "rotate-[-90deg]"}`}
+              onClick={handleAccordion}
+            >
+              <FaChevronDown className="h-4 w-4" />
+            </button>
+          ) : (
+            <TbPointFilled className="h-3 w-3" />
+          ))}
+
         {isEditing ? (
           <Input
             autoFocus={selectedNode.addTo === "list"}
@@ -100,21 +102,21 @@ export default function NodeItem({ node, parentNodeId, open, handleAccordion, op
           </span>
         )}
       </div>
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-2">
         {hover && !isEditing && (
           <>
             <button onClick={() => setIsEditing(true)}>
-              <img src={editIcon} alt="수정하기" className="h-4 w-4" />
+              <FaPencilAlt className="h-4 w-4" />
             </button>
             {node.depth < NODE_DEPTH_LIMIT ? (
               <button onClick={handleAddButton}>
-                <img src={plusIcon} alt="추가하기" className="h-4 w-4" />
+                <FaPlus className="h-4 w-4" />
               </button>
             ) : (
               <></>
             )}
             <button onClick={handleDelete}>
-              <img src={deleteIcon} alt="삭제하기" className="h-4 w-4" />
+              <FaRegTrashAlt className="h-4 w-4" />
             </button>
           </>
         )}

--- a/client/src/components/Minutes/index.tsx
+++ b/client/src/components/Minutes/index.tsx
@@ -5,11 +5,6 @@ export default function Minutes({ showMinutes, isAnimating, handleIsAnimating })
   const [width, setWidth] = useState(600);
   const startXRef = useRef(0);
   const startWidthRef = useRef(600);
-  const [text, setText] = useState("");
-
-  function getContent() {
-    console.log(text);
-  }
 
   function handleMouseDown(e: React.MouseEvent) {
     e.preventDefault();
@@ -44,12 +39,9 @@ export default function Minutes({ showMinutes, isAnimating, handleIsAnimating })
         <div onMouseDown={handleMouseDown} className="absolute left-0 top-0 z-40 h-full w-4 cursor-ew-resize" />
         <div className="flex w-full flex-col">
           <p className="mb-3 text-2xl font-bold">회의록</p>
-          <Tiptap text={text} setText={setText} />
+          <Tiptap />
           <div className="mt-2 flex justify-between">
             <p className="text-grayscale-400">편집은 마인드맵 소유자만 가능해요</p>
-            <button className="rounded-lg bg-bm-blue px-5 py-1 text-grayscale-100" onClick={getContent}>
-              저장
-            </button>
           </div>
         </div>
       </div>

--- a/client/src/components/Sidebar/Overview.tsx
+++ b/client/src/components/Sidebar/Overview.tsx
@@ -1,8 +1,4 @@
-import dashBoardIcon from "@/assets/dashboard.png";
-import listIcon from "@/assets/list.png";
 import aiIcon from "@/assets/ai.png";
-import voiceIcon from "@/assets/voiceFile.png";
-import textIcon from "@/assets/textFile.png";
 import OverviewButton from "@/components/Sidebar/OverviewButton";
 import useSection from "@/hooks/useSection";
 import { useNavigate } from "react-router-dom";
@@ -13,6 +9,11 @@ import useModal from "@/hooks/useModal";
 import { createPortal } from "react-dom";
 import LatestMindMapModal from "@/components/Sidebar/LatestMindMapModal";
 import { useState } from "react";
+import { RxDashboard } from "react-icons/rx";
+import { FaListUl } from "react-icons/fa";
+import { FaFileAlt } from "react-icons/fa";
+import { FaFileAudio } from "react-icons/fa6";
+import { RiRobot3Line } from "react-icons/ri";
 
 type ViewMode = "listview" | "voiceupload" | "textupload";
 export default function Overview() {
@@ -49,48 +50,44 @@ export default function Overview() {
     <div className="mt-14 flex flex-col text-base">
       <p className="mb-8 font-medium text-grayscale-500">OVERVIEW</p>
       <div className="flex flex-col gap-2 text-grayscale-400">
+        <OverviewButton text="대시보드" active={getmode() === "dashboard"} onclick={() => navigate("/")}>
+          <RxDashboard className="h-5 w-5" />
+        </OverviewButton>
         <OverviewButton
-          src={dashBoardIcon}
-          alt="대시보드"
-          text="대시보드"
-          active={getmode() === "dashboard"}
-          onclick={() => navigate("/")}
-        />
-        <OverviewButton
-          src={listIcon}
-          alt="리스트"
           text="리스트로 보기"
           active={getmode() === "listview"}
           onclick={() => {
             setSelcetMode("listview");
             navigateMindmap("listview");
           }}
-        />
-        <div className="flex items-center gap-6 rounded-lg p-3">
-          <img src={aiIcon} alt="ai변환" className="w-6" />
+        >
+          <FaListUl className="h-5 w-5" />
+        </OverviewButton>
+        <div className="ml-[2px] flex items-center gap-6 rounded-lg p-3">
+          <RiRobot3Line className="h-6 w-6" />
           AI 변환
         </div>
         <div className="flex flex-col gap-2 pl-5">
           <OverviewButton
-            src={voiceIcon}
-            alt="음성 파일"
             text="음성 파일 업로드"
             active={getmode() === "voiceupload"}
             onclick={() => {
               setSelcetMode("voiceupload");
               navigateMindmap("voiceupload");
             }}
-          />
+          >
+            <FaFileAudio className="h-5 w-5" />
+          </OverviewButton>
           <OverviewButton
-            src={textIcon}
-            alt="텍스트 파일"
             text="텍스트 파일 업로드"
             active={getmode() === "textupload"}
             onclick={() => {
               setSelcetMode("textupload");
               navigateMindmap("textupload");
             }}
-          />
+          >
+            <FaFileAlt className="h-5 w-5" />
+          </OverviewButton>
         </div>
       </div>
       {createPortal(

--- a/client/src/components/Sidebar/Overview.tsx
+++ b/client/src/components/Sidebar/Overview.tsx
@@ -11,21 +11,24 @@ import { useAuthStore } from "@/store/useAuthStore";
 import { getLatestMindMap } from "@/utils/localstorage";
 import useModal from "@/hooks/useModal";
 import { createPortal } from "react-dom";
-import Modal from "@/components/common/Modal";
 import LatestMindMapModal from "@/components/Sidebar/LatestMindMapModal";
+import { useState } from "react";
 
+type ViewMode = "listview" | "voiceupload" | "textupload";
 export default function Overview() {
   const navigate = useNavigate();
   const { getmode, handleViewMode } = useSection();
   const { socket, handleConnection } = useSocketStore();
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { open, closeModal, openModal } = useModal();
+  const [selectMode, setSelcetMode] = useState<ViewMode>("listview");
 
-  const navigateMindmap = (mode: "listview" | "voiceupload" | "textupload") => {
+  const navigateMindmap = (mode: ViewMode) => {
     if (socket) {
       handleViewMode(mode);
       return;
     }
+
     const latestMindMap = getLatestMindMap();
     if (!latestMindMap) {
       handleConnection(navigate, mode, isAuthenticated);
@@ -34,7 +37,7 @@ export default function Overview() {
   };
 
   function navigateToLatestMindap() {
-    navigate(`/mindmap/${getLatestMindMap()}?mode=listview`);
+    navigate(`/mindmap/${getLatestMindMap()}?mode=${selectMode}`);
     closeModal();
   }
   function navigateToNewMindMap() {
@@ -58,7 +61,10 @@ export default function Overview() {
           alt="리스트"
           text="리스트로 보기"
           active={getmode() === "listview"}
-          onclick={() => navigateMindmap("listview")}
+          onclick={() => {
+            setSelcetMode("listview");
+            navigateMindmap("listview");
+          }}
         />
         <div className="flex items-center gap-6 rounded-lg p-3">
           <img src={aiIcon} alt="ai변환" className="w-6" />
@@ -70,14 +76,20 @@ export default function Overview() {
             alt="음성 파일"
             text="음성 파일 업로드"
             active={getmode() === "voiceupload"}
-            onclick={() => navigateMindmap("voiceupload")}
+            onclick={() => {
+              setSelcetMode("voiceupload");
+              navigateMindmap("voiceupload");
+            }}
           />
           <OverviewButton
             src={textIcon}
             alt="텍스트 파일"
             text="텍스트 파일 업로드"
             active={getmode() === "textupload"}
-            onclick={() => navigateMindmap("textupload")}
+            onclick={() => {
+              setSelcetMode("textupload");
+              navigateMindmap("textupload");
+            }}
           />
         </div>
       </div>

--- a/client/src/components/Sidebar/OverviewButton.tsx
+++ b/client/src/components/Sidebar/OverviewButton.tsx
@@ -1,20 +1,20 @@
 import { Button } from "@headlessui/react";
+import { ReactElement } from "react";
 
 type ButtonProps = {
-  src: string;
-  alt: string;
   text: string;
   onclick: () => void;
   active: boolean;
+  children: JSX.Element;
 };
 
-export default function OverviewButton({ src, alt, text, onclick, active }: ButtonProps) {
+export default function OverviewButton({ text, onclick, active, children }: ButtonProps) {
   return (
     <Button
-      className={`flex items-center gap-6 rounded-lg p-3 hover:text-grayscale-100 hover:brightness-0 hover:invert ${active ? "text-white brightness-0 invert" : ""}`}
+      className={`ml-1 flex items-center gap-6 rounded-lg p-3 hover:text-grayscale-100 hover:brightness-0 hover:invert ${active ? "text-white brightness-0 invert" : ""}`}
       onClick={onclick}
     >
-      <img src={src} alt={alt} className="w-6" />
+      {children}
       {text}
     </Button>
   );

--- a/client/src/hooks/useContent.ts
+++ b/client/src/hooks/useContent.ts
@@ -1,0 +1,13 @@
+import { useState } from "react";
+
+export default function useContent() {
+  const [content, setContent] = useState("");
+  function updateContent(updatedContent: string) {
+    setContent(updatedContent);
+  }
+  function initializeContent(initialData) {
+    if (initialData.content) updateContent(initialData.content);
+  }
+
+  return { content, updateContent, initializeContent };
+}

--- a/client/src/hooks/useMindMapTitle.ts
+++ b/client/src/hooks/useMindMapTitle.ts
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+export default function useMindMapTitle() {
+  const [title, setTitle] = useState("제목없는 마인드맵");
+
+  function updateTitle(newTitle: string) {
+    setTitle(newTitle);
+  }
+
+  function initializeTitle(initializeData) {
+    if (initializeData.title) setTitle(initializeData.title);
+  }
+
+  return { title, updateTitle, initializeTitle };
+}

--- a/client/src/konva_mindmap/utils/throttle.ts
+++ b/client/src/konva_mindmap/utils/throttle.ts
@@ -1,10 +1,8 @@
+let timer = null;
 export function throttle(fn: any, delay: number) {
-  let timer = null;
-  return (function () {
-    if (timer) return;
-    timer = setTimeout(() => {
-      fn();
-      timer = null;
-    }, delay);
-  })();
+  if (timer) return;
+  timer = setTimeout(() => {
+    fn();
+    timer = null;
+  }, delay);
 }

--- a/client/src/store/useSocketStore.ts
+++ b/client/src/store/useSocketStore.ts
@@ -1,6 +1,13 @@
 import { Socket, io } from "socket.io-client";
 import { create } from "zustand";
-import { actionType, createNodePayload, updateNodePayload, deleteNodePayload } from "@/types/NodePayload";
+import {
+  actionType,
+  createNodePayload,
+  updateNodePayload,
+  deleteNodePayload,
+  updateTitlePayload,
+  updateContentPayload,
+} from "@/types/NodePayload";
 import { createMindmap } from "@/api/mindmap.api";
 import { NavigateFunction } from "react-router-dom";
 import { setOwner } from "@/utils/localstorage";
@@ -15,7 +22,7 @@ type SocketState = {
 
 type HandleSocketEventProps = {
   actionType: actionType;
-  payload: createNodePayload | updateNodePayload | deleteNodePayload;
+  payload: createNodePayload | updateNodePayload | deleteNodePayload | updateTitlePayload | updateContentPayload;
   callback?: (response?: any) => void;
 };
 

--- a/client/src/types/NodePayload.ts
+++ b/client/src/types/NodePayload.ts
@@ -1,6 +1,6 @@
 import { NodeData } from "./Node";
 
-export type actionType = "createNode" | "deleteNode" | "updateNode";
+export type actionType = "createNode" | "deleteNode" | "updateNode" | "updateTitle" | "updateContent";
 
 export type createNodePayload = {
   id: number;
@@ -17,3 +17,6 @@ export type deleteNodePayload = {
 };
 
 export type updateNodePayload = NodeData;
+
+export type updateTitlePayload = { title: string };
+export type updateContentPayload = { content: string };


### PR DESCRIPTION
#132 소유자는 헤더의 마인드맵 제목이나 회의록의 내용을 변경할 수 있으며, 변경 내용은 broadcast되어 동시 편집중인 모든 사람들에게 보인다.

## 작업 내용
- 제목과 회의록에 소켓 이벤트를 부착하고, broadcast될 때 다른 사용자들 또한 변경사항이 반영될 수 있도록 변경했습니다.
- 로그인 유저가 마인드맵 상태에서 새로고침 했을 때, 다시금 토큰을 refresh 하고 이에 따른 사용자 권한을 검사할 수 있도록 로직을 추가했습니다.
- 제목의 경우 제대로 소켓 이벤트가 가지 않으면 기존의 값으로 롤백될 수 있도록 하였습니다.
- 회의록 소켓 이벤트의 경우에는 쓰로틀링을 활용하여 1.5초마다 한번씩 회의록 본문을 소켓으로 보낼 수 있도록 하였습니다.
- nodeListProvider에 제목과 회의록을 위한 커스텀 훅을 별도로 분리하여 해당 훅에서 실행할 수 있도록 하였습니다./

## 논의하고 싶은 내용
NodeListProvider가 이전 노드만의 데이터를 다룰 때에는 적당한 네이밍이라고 생각했지만, 해당 마인드맵의 정보를 모두 관리하게 되면서 사이즈가 점점 커지고 이를 보다 커스텀 훅으로 각각의 역할을 분리하는 것이 좋을 것 같다는 생각이 듭니다.
추가적으로 비단 노드만의 데이터를 관리한다기에는 이제는 마인드맵 데이터의 전체를 관리하는 context api가 되었기 때문에 네이밍도 변경할 필요성이 있어 보입니다.
