### PR TITLE
[Feature-3-2-fix-fe] 마인드맵 재정렬 로직 수정 & 모달 UI 통일 &

### DIFF
--- a/client/src/components/DeleteMindMapModal/index.tsx
+++ b/client/src/components/DeleteMindMapModal/index.tsx
@@ -9,11 +9,14 @@ export default function DeleteMindMapModal({ open, closeModal, confirmDelete, da
         <br></br>마인드 맵을 삭제하시겠습니까?
       </p>
       <div className="flex justify-center gap-2">
-        <Button onClick={closeModal} className="rounded-lg px-4 py-2 text-gray-500 hover:bg-gray-100">
-          취소
+        <Button
+          onClick={closeModal}
+          className="flex-1 rounded-lg bg-grayscale-100 py-2.5 text-center text-sm text-black hover:brightness-90"
+        >
+          안할래요
         </Button>
-        <Button onClick={confirmDelete} className="rounded-lg px-4 py-2 text-red-600 hover:bg-red-100">
-          삭제
+        <Button onClick={confirmDelete} className="flex-1 rounded-lg bg-red-500 py-2.5 text-sm hover:brightness-90">
+          삭제할게요
         </Button>
       </div>
     </Modal>

--- a/client/src/components/MindMapCanvas/CanvasButtons.tsx
+++ b/client/src/components/MindMapCanvas/CanvasButtons.tsx
@@ -5,7 +5,7 @@ import { useSocketStore } from "@/store/useSocketStore";
 import { Button } from "@headlessui/react";
 import { createPortal } from "react-dom";
 
-export default function CanvasButtons({ handleReArrange, showMinutes, handleShowMinutes }) {
+export default function CanvasButtons({ handleReArrange, handleCenterMove, showMinutes, handleShowMinutes }) {
   const { handleSocketEvent } = useSocketStore();
   const { overrideNodeData } = useNodeListContext();
   const { open, openModal, closeModal } = useModal();
@@ -21,12 +21,20 @@ export default function CanvasButtons({ handleReArrange, showMinutes, handleShow
     });
   };
 
+  function handleReArrangeAndMoveCenter() {
+    handleReArrange();
+    handleCenterMove();
+  }
+
   return (
     <div className="absolute right-0 top-[-50px] flex gap-3">
       <Button className="rounded-lg bg-grayscale-600 px-4 py-2 text-sm font-bold" onClick={handleShowMinutes}>
         {!showMinutes ? "회의록 보기" : "회의록 닫기"}
       </Button>
-      <Button className="rounded-lg bg-grayscale-600 px-4 py-2 text-sm font-bold" onClick={handleReArrange}>
+      <Button
+        className="rounded-lg bg-grayscale-600 px-4 py-2 text-sm font-bold"
+        onClick={handleReArrangeAndMoveCenter}
+      >
         캔버스 재정렬
       </Button>
       <Button className="rounded-lg bg-grayscale-600 px-4 py-2 text-sm font-bold" onClick={openModal}>

--- a/client/src/components/MindMapCanvas/DeleteConfirmModal.tsx
+++ b/client/src/components/MindMapCanvas/DeleteConfirmModal.tsx
@@ -9,16 +9,17 @@ type DeleteConfirmModalProps = {
 export default function DeleteConfirmModal({ open, closeModal, onConfirm }: DeleteConfirmModalProps) {
   return (
     <Modal open={open} closeModal={closeModal}>
-      <div className="flex h-full w-full flex-col items-center justify-center gap-2">
-        <p className="text-black">모든 노드를 초기화할까요?</p>
-        <div className="flex w-full gap-4">
-          <Button className="w-1/2 rounded-md bg-red-500 py-1" onClick={onConfirm}>
-            초기화할게요
-          </Button>
-          <Button className="w-1/2 rounded-md border border-grayscale-300 py-1 text-black" onClick={closeModal}>
-            안할래요
-          </Button>
-        </div>
+      <p className="mb-4 text-lg font-bold text-black">모든 노드를 초기화할까요?</p>
+      <div className="flex justify-center gap-2">
+        <Button
+          onClick={closeModal}
+          className="flex-1 rounded-lg bg-grayscale-100 py-2.5 text-center text-sm text-black hover:brightness-90"
+        >
+          안할래요
+        </Button>
+        <Button onClick={onConfirm} className="flex-1 rounded-lg bg-red-500 py-2.5 text-sm hover:brightness-90">
+          초기화할게요
+        </Button>
       </div>
     </Modal>
   );

--- a/client/src/components/MindMapCanvas/ShowShortCut.tsx
+++ b/client/src/components/MindMapCanvas/ShowShortCut.tsx
@@ -6,6 +6,7 @@ const shortcuts = [
   { keys: ["="], description: "노드 추가" },
   { keys: ["Backspace"], description: "노드 삭제" },
   { keys: ["Shift", "Drag"], description: "노드 다중 선택" },
+  { keys: ["Shift", "Move"], description: "하위 노드 이동" },
   { keys: ["SpaceBar"], description: "손모양 전환" },
   { keys: ["Ctrl", "Z"], description: "뒤로가기" },
   { keys: ["Ctrl", "Shift", "Z"], description: "앞으로가기" },

--- a/client/src/components/MindMapCanvas/ToolMenu.tsx
+++ b/client/src/components/MindMapCanvas/ToolMenu.tsx
@@ -45,47 +45,51 @@ export default function ToolMenu({ dimensions, zoomIn, zoomOut, dragmode, setDra
   return (
     <div className="absolute bottom-2 left-1/2 flex -translate-x-2/4 -translate-y-2/4 items-center justify-center rounded-full border bg-white px-6 py-2 shadow-md">
       <div className="flex items-center gap-3">
-        <div className="flex items-center gap-3 px-1">
-          <Button
-            className={`rounded-md p-1 hover:bg-blue-300 ${dragmode ? "bg-blue-400" : ""}`}
-            onClick={() => setDragmode(true)}
-          >
-            <FaRegHandPaper
-              className={`mr-[2px] h-[18px] w-[18px] ${dragmode ? "fill-grayscale-100" : "fill-grayscale-400"}`}
-            />
-          </Button>
-          <Button
-            className={`rounded-md p-1 ${dragmode ? "hover:bg-blue-300" : "bg-blue-400"}`}
-            onClick={() => setDragmode(false)}
-          >
-            <PiCursorFill
-              className={`h-5 w-5 hover:fill-grayscale-100 ${dragmode ? "fill-gray-400" : "fill-grayscale-100"}`}
-            />
-          </Button>
-          <div className="flex items-center gap-3 border-x-2 px-3">
-            <Button
-              className="rounded-md p-1 hover:bg-blue-300"
-              onMouseDown={() => startZoom(zoomIn)}
-              onMouseUp={stopZoom}
-            >
-              <TiZoomInOutline className="h-6 w-6 fill-grayscale-400 hover:fill-gray-100" />
-            </Button>
-            <span className="w-8 text-center text-sm font-bold text-black">{Math.floor(dimensions.scale * 100)}%</span>
-            <Button
-              className="rounded-md p-1 hover:bg-blue-300"
-              onMouseDown={() => startZoom(zoomOut)}
-              onMouseUp={stopZoom}
-              onMouseLeave={stopZoom}
-            >
-              <TiZoomOutOutline className="h-6 w-6 fill-grayscale-400 hover:fill-gray-100" />
-            </Button>
-          </div>
-        </div>
-        <Button className="rounded-md fill-gray-100 p-1 hover:bg-blue-300" onClick={handleAddButton}>
-          <TbCirclePlus2 className="mr-1 h-5 w-5 stroke-grayscale-400 hover:fill-gray-100" />
+        <Button
+          className={`group flex h-8 w-8 items-center justify-center rounded-md p-1 hover:bg-blue-300 ${dragmode ? "bg-blue-400" : ""}`}
+          onClick={() => setDragmode(true)}
+        >
+          <FaRegHandPaper
+            className={`mr-[2px] h-[18px] w-[18px] group-hover:fill-gray-100 ${dragmode ? "fill-grayscale-100" : "fill-grayscale-400"}`}
+          />
         </Button>
-        <Button className="rounded-md p-1 hover:bg-blue-300" onClick={handleDeleteButton}>
-          <FaRegTrashAlt className="h-[18px] w-[18px] fill-grayscale-400 hover:fill-gray-100" />
+        <Button
+          className={`group flex h-8 w-8 items-center justify-center rounded-md p-1 ${dragmode ? "hover:bg-blue-300" : "bg-blue-400"}`}
+          onClick={() => setDragmode(false)}
+        >
+          <PiCursorFill
+            className={`h-5 w-5 hover:fill-grayscale-100 ${dragmode ? "fill-gray-400" : "fill-grayscale-100"}`}
+          />
+        </Button>
+        <div className="flex items-center gap-3 border-x-2 px-3">
+          <Button
+            className="group flex h-8 w-8 items-center justify-center rounded-md p-1 hover:bg-blue-300"
+            onMouseDown={() => startZoom(zoomIn)}
+            onMouseUp={stopZoom}
+          >
+            <TiZoomInOutline className="h-6 w-6 fill-grayscale-400 group-hover:fill-gray-100" />
+          </Button>
+          <span className="w-8 text-center text-sm font-bold text-black">{Math.floor(dimensions.scale * 100)}%</span>
+          <Button
+            className="group flex h-8 w-8 items-center justify-center rounded-md p-1 hover:bg-blue-300"
+            onMouseDown={() => startZoom(zoomOut)}
+            onMouseUp={stopZoom}
+            onMouseLeave={stopZoom}
+          >
+            <TiZoomOutOutline className="h-6 w-6 fill-grayscale-400 group-hover:fill-gray-100" />
+          </Button>
+        </div>
+        <Button
+          className="group flex h-8 w-8 items-center justify-center rounded-md fill-gray-100 p-1 hover:bg-blue-300"
+          onClick={handleAddButton}
+        >
+          <TbCirclePlus2 className="h-5 w-5 stroke-grayscale-400 group-hover:fill-blue-300 group-hover:stroke-gray-100" />
+        </Button>
+        <Button
+          className="group flex h-8 w-8 items-center justify-center rounded-md p-1 hover:bg-blue-300"
+          onClick={handleDeleteButton}
+        >
+          <FaRegTrashAlt className="h-[18px] w-[18px] fill-grayscale-400 group-hover:fill-gray-100" />
         </Button>
       </div>
     </div>

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -30,7 +30,7 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
     selectedNode,
   } = useNodeListContext();
   const [isDragMode, setDragMode] = useState(false);
-  const { dimensions, targetRef, handleWheel, zoomIn, zoomOut } = useDimension(data);
+  const { dimensions, targetRef, handleWheel, zoomIn, zoomOut, centerMoveMap } = useDimension(data);
   const registerLayer = useCollisionDetection(data, updateNode);
   const stageRef = useRef();
   const { registerStageRef } = useStageStore();
@@ -132,6 +132,7 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
       ) : (
         <CanvasButtons
           handleReArrange={handleReArrange}
+          handleCenterMove={centerMoveMap}
           showMinutes={showMinutes}
           handleShowMinutes={handleShowMinutes}
         />

--- a/client/src/components/ShareModal/index.tsx
+++ b/client/src/components/ShareModal/index.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@headlessui/react";
+import { Button, Input } from "@headlessui/react";
 import Modal from "../common/Modal";
 import { useState } from "react";
 import { FiCopy, FiCheck } from "react-icons/fi";
@@ -33,13 +33,13 @@ export default function ShareModal({ open, closeModal }: ShareModalProps) {
           readOnly
           className="pointer-events-none h-10 w-full truncate rounded-lg bg-grayscale-200 px-3 py-2 text-grayscale-500"
         />
-        <button
+        <Button
           onClick={copyLink}
           className="mt-2 flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-bm-blue transition hover:brightness-90"
         >
           {copySuccess === true ? <FiCheck size={18} /> : <FiCopy size={18} />}
           <p className="text-sm">{copySuccess === true ? "복사 완료" : "링크 복사"}</p>
-        </button>
+        </Button>
         <p className="mt-3 border-t pt-1 text-[10px] text-grayscale-400">
           복사된 링크를 통해 팀원들과 브레인스토밍을 해보세요
         </p>

--- a/client/src/konva_mindmap/components/EditableTextInput.tsx
+++ b/client/src/konva_mindmap/components/EditableTextInput.tsx
@@ -1,7 +1,6 @@
 import { Html } from "react-konva-utils";
 
 interface EditableTextInputProps {
-  ref?: React.RefObject<HTMLInputElement>;
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;

--- a/client/src/konva_mindmap/components/NewNode.tsx
+++ b/client/src/konva_mindmap/components/NewNode.tsx
@@ -4,14 +4,14 @@ import { addNode } from "@/konva_mindmap/events/addNode";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { useSocketStore } from "@/store/useSocketStore";
 import { NodeProps } from "@/types/Node";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { Circle, Group } from "react-konva";
+import { NODE_RADIUS, NODE_WIDTH_AND_HEIGHT, TEXT_OFFSET_X, TEXT_OFFSET_Y, TEXT_WIDTH } from "../utils/nodeAttrs";
 
 export default function NewNode({ data, node, depth }: NodeProps) {
   const { saveHistory, selectedNode, updateNode } = useNodeListContext();
   const [keyword, setKeyword] = useState("제목없음");
   const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
-  const inputRef = useRef<HTMLInputElement | null>(null);
 
   function handleTextChange(e: React.ChangeEvent<HTMLInputElement>) {
     setKeyword(e.target.value);
@@ -28,7 +28,6 @@ export default function NewNode({ data, node, depth }: NodeProps) {
         addNode(content, node.id, updateNode);
       },
     });
-    inputRef.current?.blur();
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
@@ -44,19 +43,18 @@ export default function NewNode({ data, node, depth }: NodeProps) {
     <Group name="newNode" id={node.id.toString()} x={node.location.x} y={node.location.y}>
       <Circle
         fill={selectedNode?.nodeId === node.id ? "orange" : colors[depth - 1]}
-        width={100}
-        height={100}
+        width={NODE_WIDTH_AND_HEIGHT}
+        height={NODE_WIDTH_AND_HEIGHT}
         strokeWidth={3}
-        radius={60 - depth * 10}
+        radius={NODE_RADIUS(depth)}
         shadowBlur={5}
       />
       <EditableTextInput
-        ref={inputRef}
         focus={selectedNode.addTo === "canvas"}
         value={keyword}
-        offsetX={70 - depth * 10}
-        offsetY={8 * depth - 60}
-        width={140 - depth * 20}
+        offsetX={TEXT_OFFSET_X(depth)}
+        offsetY={TEXT_OFFSET_Y(depth)}
+        width={TEXT_WIDTH(depth)}
         onBlur={handleBlur}
         onChange={handleTextChange}
         onKeyDown={handleKeyDown}

--- a/client/src/konva_mindmap/events/addNode.ts
+++ b/client/src/konva_mindmap/events/addNode.ts
@@ -97,16 +97,16 @@ function getNewNodePosition(children: number[], data: NodeData, parentNode: Node
   if (!children.length) {
     if (parentNode.id === rootKey)
       return {
-        x: parentNode.location.x + 110,
+        x: parentNode.location.x + 300,
         y: parentNode.location.y,
       };
-    const { x, y } = calculateVector(data[rootKey].location, parentNode.location, -80, 140);
+    const { x, y } = calculateVector(data[rootKey].location, parentNode.location, -80, 240);
     return parentNode ? { x: parentNode.location.x + x, y: parentNode.location.y + y } : { x: 0, y: 0 };
   }
   const lastChildren = data[children[children.length - 1]];
-  const uv = calculateVector(parentNode.location, lastChildren.location, 110);
+  const uv = calculateVector(parentNode.location, lastChildren.location, 110, 240);
   return {
-    x: lastChildren.location.x + uv.x * 100,
-    y: lastChildren.location.y + uv.y * 100,
+    x: lastChildren.location.x + uv.x,
+    y: lastChildren.location.y + uv.y,
   };
 }

--- a/client/src/konva_mindmap/hooks/useAdjustedStage.ts
+++ b/client/src/konva_mindmap/hooks/useAdjustedStage.ts
@@ -4,7 +4,6 @@ import { findRootNodeKey } from "../utils/findRootNodeKey";
 
 export function useAdjustedStage(data: NodeData, containerWidth: number, containerHeight: number) {
   const [adjustedDimensions, setAdjustedDimensions] = useState({ scale: 1, x: 0, y: 0 });
-
   const rootKey = findRootNodeKey(data);
 
   useEffect(() => {
@@ -45,7 +44,7 @@ export function useAdjustedStage(data: NodeData, containerWidth: number, contain
     const scaleY = containerHeight / height;
     let scale = Math.min(scaleX, scaleY);
     if (scale >= 1.5) scale = 1.5;
-    else if (scale <= 0.5) scale = 0.5;
+    else if (scale <= 0.25) scale = 0.25;
 
     return {
       scale,

--- a/client/src/konva_mindmap/hooks/useDimension.ts
+++ b/client/src/konva_mindmap/hooks/useDimension.ts
@@ -28,11 +28,15 @@ export default function useDimension(data) {
   }, [targetRef]);
 
   useEffect(() => {
+    centerMoveMap();
+  }, [adjustedDimensions]);
+
+  function centerMoveMap() {
     setDimensions((prev) => ({
       ...prev,
       ...adjustedDimensions,
     }));
-  }, [adjustedDimensions]);
+  }
 
   function resizing() {
     if (targetRef.current) {
@@ -69,5 +73,6 @@ export default function useDimension(data) {
     handleWheel,
     zoomIn,
     zoomOut,
+    centerMoveMap,
   };
 }

--- a/client/src/konva_mindmap/utils/initializeNodePosition.ts
+++ b/client/src/konva_mindmap/utils/initializeNodePosition.ts
@@ -1,5 +1,7 @@
 import { NodeData } from "@/types/Node";
 import { findRootNodeKey } from "./findRootNodeKey";
+import { NODE_RADIUS } from "./nodeAttrs";
+import { calculateVector } from "./vector";
 
 type CalculateNodePositionParams = {
   nodeId: number;
@@ -7,52 +9,87 @@ type CalculateNodePositionParams = {
   index: number;
   xPos: number;
   yPos: number;
-  angle: number;
 };
 
 export default function initializeNodePosition(data: NodeData) {
   if (!Object.keys(data).length) return data;
+
+  const rootKey = findRootNodeKey(data);
+  const rootLocation = data[rootKey].location;
+
   calculateNodePosition({
-    nodeId: findRootNodeKey(data),
+    nodeId: rootKey,
     length: 0,
     index: 0,
     xPos: 0,
     yPos: 0,
-    angle: 0,
   });
 
-  function calculateNodePosition({ nodeId, length, index, xPos, yPos, angle }: CalculateNodePositionParams) {
+  function findAncestor(data: NodeData, targetId: number, level: number) {
+    function findParent(data, childId) {
+      for (const key in data) {
+        const node = data[key];
+        if (node.children && node.children.includes(childId)) {
+          return node;
+        }
+      }
+      return null;
+    }
+
+    let currentNodeId = targetId;
+    let currentLevel = 0;
+    while (currentLevel < level) {
+      const parent = findParent(data, currentNodeId);
+      if (!parent) return null;
+      currentNodeId = parent.id;
+      currentLevel++;
+    }
+    return data[currentNodeId];
+  }
+
+  function calculateNodePosition({ nodeId, length, index, xPos, yPos }: CalculateNodePositionParams) {
     const node = data[nodeId];
     const depth = node.depth;
-    const radius = 60 - 10 * depth;
+    const radius = NODE_RADIUS(depth);
 
     if (depth === 2) {
-      angle = (360 / length) * index;
+      const angle = (360 / length) * index;
       const radianAngle = (Math.PI / 180) * angle;
-      xPos += radius * length * 0.8 * Math.cos(radianAngle);
-      yPos += radius * length * 0.8 * Math.sin(radianAngle);
+      xPos += radius * Math.cos(radianAngle) * 8;
+      yPos += radius * Math.sin(radianAngle) * 8;
     } else if (depth === 3) {
       const divideAngle = 180 / (length + 1);
-      const adjustedAngle = angle - 90 + divideAngle * (index + 1);
-      const radianAngle = (Math.PI / 180) * adjustedAngle;
-
-      const calculatedDistance = Math.sqrt((2 * radius * radius) / (1 - Math.cos((Math.PI / 180) * divideAngle))) + 30;
-      const distance = Math.max(calculatedDistance, 100);
-      xPos += distance * Math.cos(radianAngle);
-      yPos += distance * Math.sin(radianAngle);
+      const adjustedAngle = divideAngle * (index + 1) - 90;
+      const { x, y } = calculateVector(rootLocation, { x: xPos, y: yPos }, adjustedAngle, 360);
+      xPos += x;
+      yPos += y;
+    } else if (depth === 4) {
+      const divideAngle = 180 / (length + 3);
+      const adjustedAngle = divideAngle * (index + 2) - 90;
+      const { x, y } = calculateVector(rootLocation, { x: xPos, y: yPos }, adjustedAngle, 360);
+      xPos += x;
+      yPos += y;
+    } else if (depth === 5) {
+      const ancestor = findAncestor(data, nodeId, 2);
+      const divideAngle = 180 / (length + 1);
+      const adjustedAngle = divideAngle * (index + 1) - 90;
+      const calculatedDistance = Math.sqrt((2 * radius * radius) / (1 - Math.cos((Math.PI / 180) * divideAngle))) * 1.8;
+      const maxDistance = Math.max(calculatedDistance, 200);
+      const { x, y } = calculateVector(ancestor.location, { x: xPos, y: yPos }, adjustedAngle, maxDistance);
+      xPos += x;
+      yPos += y;
     }
     node.location.x = xPos;
     node.location.y = yPos;
 
     {
-      node.children.map((childId, childIndex) => {
+      node.children.map((childId: number, childIndex: number) => {
         calculateNodePosition({
           nodeId: childId,
           length: node.children.length,
           xPos,
           yPos,
           index: childIndex,
-          angle,
         });
       });
     }

--- a/client/src/konva_mindmap/utils/nodeAttrs.ts
+++ b/client/src/konva_mindmap/utils/nodeAttrs.ts
@@ -6,7 +6,7 @@ export const NODE_WIDTH_AND_HEIGHT = 100;
 export const NODE_RADIUS = (depth: number) => NODE_DEFAULT_SIZE - depth * NODE_DEFAULT_RATIO;
 export const TEXT_OFFSET_X = (depth: number) => NODE_DEFAULT_SIZE - depth * 10;
 export const TEXT_OFFSET_Y = (depth: number) => 5 * depth - NODE_DEFAULT_SIZE - 5;
-export const TEXT_WIDTH = (depth: number) => NODE_DEFAULT_SIZE * 2 - depth * 20;
+export const TEXT_WIDTH = (depth: number) => NODE_DEFAULT_SIZE * 2 - depth * 18;
 
 //CONNECTED_LINE
 export const CONNECTED_LINE_FROM = (depth: number) => NODE_DEFAULT_SIZE - depth * 7 + 10;


### PR DESCRIPTION
## 작업 내용
- 마인드맵 재정렬 로직
- 마인드맵 재정렬 시 영역 가운대로 위치 이동
- 모달 UI 수정 & 통일
- ToolBar UI 수정 & hover 수정
- input 크기 조정

## 논의하고 싶은 내용
1. 마인드맵에서 드래그만 한 상태에서 재정렬을 누르게 되면 dimension에서 변경사항이 없기 때문에 가운대로 위치 이동이 되지 않는데 이 부분이 잘 안되고 있습니다ㅜㅜ 여러 시도들을 해봤는데 잘 안되네요..
2. 마인드맵 초기 영역 비율이 처음부터 끝까지 계속 유지가 되다 보니 새로고침을 하기 전까지는 계속 비율이 일정한 상태에서 재정렬이 돌게 되네요.. 그래서 의존성 배열에 data를 넣자니 data가 변경될때마다 함수가 일어나게 되서 일단은 빼놨는데.. 어떻게 해야될까요ㅜㅜ
그리고 노드가 영역 바깥 쪽에서 생성되었을 때 input에 focus가 일어나면서 캔버스 영역의 이동이 일어나는데 이 부분도 해결해야 될 것 같습니다ㅜㅜ