### PR TITLE
[Feature-6-9-fe-fix] 대시보드에서 마인드맵 이동시 api 호출과 소켓 연결 후 이동 보완

### DIFF
--- a/client/src/api/mindmap.api.ts
+++ b/client/src/api/mindmap.api.ts
@@ -4,6 +4,10 @@ export function createMindmap() {
   return instance.post("/connection");
 }
 
+export function getMindMap(mindMapId) {
+  return instance.get(`/connection/${mindMapId}`);
+}
+
 export function deleteMindMap(mindMapId: string) {
   return instance.delete(`/mindmap/${mindMapId}`);
 }

--- a/client/src/components/Dashboard/MindMapInfoItem.tsx
+++ b/client/src/components/Dashboard/MindMapInfoItem.tsx
@@ -9,6 +9,7 @@ import { FaRegTrashAlt } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import { useDeleteMindMap } from "@/api/fetchHooks/useDeleteMindMap";
 import { DashBoard } from "@/konva_mindmap/types/dashboard";
+import { useSocketStore } from "@/store/useSocketStore";
 
 interface MindMapInfoItemProps {
   data: DashBoard;
@@ -24,6 +25,7 @@ export default function MindMapInfoItem({ data, index }: MindMapInfoItemProps) {
     mindMapId: data.id.toString(),
     onError: (error) => console.log(error),
   });
+  const handleConnection = useSocketStore((state) => state.getConnection);
 
   const ownerCheck = name === data.owner;
 
@@ -31,8 +33,14 @@ export default function MindMapInfoItem({ data, index }: MindMapInfoItemProps) {
     mutation.mutate();
     closeModal();
   }
-  function navigateToMindMap() {
-    navigate(`/mindmap/${data.connectionId}?mode=listview`);
+
+  async function navigateToMindMap() {
+    try {
+      await handleConnection(data.id, data.connectionId);
+      navigate(`/mindmap/${data.connectionId}?mode=listview`);
+    } catch (error) {
+      throw error;
+    }
   }
 
   return (

--- a/client/src/components/Dashboard/MindMapInfoItem.tsx
+++ b/client/src/components/Dashboard/MindMapInfoItem.tsx
@@ -18,7 +18,7 @@ interface MindMapInfoItemProps {
 
 export default function MindMapInfoItem({ data, index }: MindMapInfoItemProps) {
   const { open, openModal, closeModal } = useModal();
-  const { name } = useAuthStore();
+  const { id } = useAuthStore();
   const keywordData = data.keyword.slice(0, 4);
   const navigate = useNavigate();
   const mutation = useDeleteMindMap({
@@ -27,7 +27,7 @@ export default function MindMapInfoItem({ data, index }: MindMapInfoItemProps) {
   });
   const getConnection = useSocketStore((state) => state.getConnection);
 
-  const ownerCheck = name === data.owner;
+  const ownerCheck = id === data.ownerId;
 
   function handleDelete() {
     mutation.mutate();

--- a/client/src/components/Dashboard/MindMapInfoItem.tsx
+++ b/client/src/components/Dashboard/MindMapInfoItem.tsx
@@ -58,7 +58,7 @@ export default function MindMapInfoItem({ data, index }: MindMapInfoItemProps) {
         </div>
         <div className="flex min-w-24 items-center justify-center gap-2">
           <img className="h-6 w-6" src={profile} alt="소유자 이미지" />
-          <div>{data.owner}</div>
+          <div>{data.ownerName}</div>
         </div>
         <div className="flex min-w-40 justify-between">
           <div>{extractDate(new Date(data.createDate))}</div>

--- a/client/src/components/Dashboard/MindMapInfoItem.tsx
+++ b/client/src/components/Dashboard/MindMapInfoItem.tsx
@@ -25,7 +25,7 @@ export default function MindMapInfoItem({ data, index }: MindMapInfoItemProps) {
     mindMapId: data.id.toString(),
     onError: (error) => console.log(error),
   });
-  const handleConnection = useSocketStore((state) => state.getConnection);
+  const getConnection = useSocketStore((state) => state.getConnection);
 
   const ownerCheck = name === data.owner;
 
@@ -34,13 +34,9 @@ export default function MindMapInfoItem({ data, index }: MindMapInfoItemProps) {
     closeModal();
   }
 
-  async function navigateToMindMap() {
-    try {
-      await handleConnection(data.id, data.connectionId);
-      navigate(`/mindmap/${data.connectionId}?mode=listview`);
-    } catch (error) {
-      throw error;
-    }
+  function navigateToMindMap() {
+    getConnection(data.id, data.connectionId);
+    navigate(`/mindmap/${data.connectionId}?mode=listview`);
   }
 
   return (

--- a/client/src/components/MindMapMainSection/ControlSection/TextUpload.tsx
+++ b/client/src/components/MindMapMainSection/ControlSection/TextUpload.tsx
@@ -19,7 +19,7 @@ export default function TextUpload() {
           {content.length}/{TEXT_UPLOAD_LIMIT}
         </p>
       </div>
-      <Button className="rounded-xl bg-bm-blue p-3">🚀 만들기</Button>
+      <Button className="rounded-xl bg-bm-blue p-3">만들기</Button>
     </div>
   );
 }

--- a/client/src/components/Sidebar/Overview.tsx
+++ b/client/src/components/Sidebar/Overview.tsx
@@ -33,10 +33,13 @@ export default function Overview() {
     const latestMindMap = getLatestMindMap();
     if (!latestMindMap) {
       handleConnection(navigate, mode, isAuthenticated);
+      return;
     }
     openModal();
   };
 
+  //비회원은 삭제를 안한다
+  //setConnection
   function navigateToLatestMindap() {
     navigate(`/mindmap/${getLatestMindMap()}?mode=${selectMode}`);
     closeModal();

--- a/client/src/store/useAuthStore.ts
+++ b/client/src/store/useAuthStore.ts
@@ -4,14 +4,16 @@ import { create } from "zustand";
 type UserStore = {
   email: null | string;
   name: null | string;
+  id: null | number;
   isAuthenticated: boolean;
   checkAuthenticated: () => void;
   logout: () => void;
-  setUser: (email: string, name: string) => void;
+  setUser: (email: string, name: string, id: number) => void;
 };
 export const useAuthStore = create<UserStore>((set) => ({
   email: null,
   name: null,
+  id: null,
   isAuthenticated: false,
 
   checkAuthenticated: () => {
@@ -26,7 +28,7 @@ export const useAuthStore = create<UserStore>((set) => ({
     set({ email: null, name: null, isAuthenticated: false });
   },
 
-  setUser: (email: string, name: string) => {
-    set({ email: email, name: name, isAuthenticated: true });
+  setUser: (email: string, name: string, id: number) => {
+    set({ email, name, id, isAuthenticated: true });
   },
 }));

--- a/client/src/store/useSocketStore.ts
+++ b/client/src/store/useSocketStore.ts
@@ -8,7 +8,7 @@ import {
   updateTitlePayload,
   updateContentPayload,
 } from "@/types/NodePayload";
-import { createMindmap } from "@/api/mindmap.api";
+import { createMindmap, getMindMap } from "@/api/mindmap.api";
 import { NavigateFunction } from "react-router-dom";
 import { setOwner } from "@/utils/localstorage";
 
@@ -18,6 +18,7 @@ type SocketState = {
   disconnectSocket: () => void;
   handleSocketEvent: (props: HandleSocketEventProps) => void;
   handleConnection: (navigate: NavigateFunction, targetMode: string, isAuthenticated: boolean) => void;
+  getConnection: (mindMapId: number, connectionId: string) => void;
   wsError: string[];
   currentJobStatus: string;
   connectionStatus: string;
@@ -92,5 +93,12 @@ export const useSocketStore = create<SocketState>((set, get) => ({
     } catch (error) {
       console.error(error);
     }
+  },
+
+  getConnection: async (mindMapId: number, connectionId: string) => {
+    const socket = get().socket;
+    if (socket) socket.disconnect();
+    const response = await getMindMap(mindMapId.toString());
+    get().connectSocket(connectionId);
   },
 }));

--- a/client/src/store/useSocketStore.ts
+++ b/client/src/store/useSocketStore.ts
@@ -96,9 +96,13 @@ export const useSocketStore = create<SocketState>((set, get) => ({
   },
 
   getConnection: async (mindMapId: number, connectionId: string) => {
-    const socket = get().socket;
-    if (socket) socket.disconnect();
-    const response = await getMindMap(mindMapId.toString());
-    get().connectSocket(connectionId);
+    try {
+      const socket = get().socket;
+      if (socket) socket.disconnect();
+      const response = await getMindMap(mindMapId.toString());
+      get().connectSocket(connectionId);
+    } catch (error) {
+      throw error;
+    }
   },
 }));


### PR DESCRIPTION
## 작업내용
- 대시보드에서 마인드맵으로 이동했을 경우 기존에 있었던 navigate 로직을 제거하고 api 요청 후에 소켓 연결을 하고, 이후 이동을 할 수 있도록 로직을 보완했습니다.
- 최근 이동했던 마인드맵이 없을 경우에도 모달이 뜨던 문제를 수정했습니다.