### PR TITLE
[Feature-3-20-fe] 마인드맵을 클릭하면 노드 위에 툴을 통해서도 수정, 삭제, 추가가 가능하다 

### DIFF
--- a/client/src/components/MindMapCanvas/ToolMenu.tsx
+++ b/client/src/components/MindMapCanvas/ToolMenu.tsx
@@ -65,6 +65,7 @@ export default function ToolMenu({ dimensions, zoomIn, zoomOut, dragmode, setDra
           <Button
             className="group flex h-8 w-8 items-center justify-center rounded-md p-1 hover:bg-blue-300"
             onMouseDown={() => startZoom(zoomIn)}
+            onClick={zoomIn}
             onMouseUp={stopZoom}
           >
             <TiZoomInOutline className="h-6 w-6 fill-grayscale-400 group-hover:fill-gray-100" />
@@ -73,6 +74,7 @@ export default function ToolMenu({ dimensions, zoomIn, zoomOut, dragmode, setDra
           <Button
             className="group flex h-8 w-8 items-center justify-center rounded-md p-1 hover:bg-blue-300"
             onMouseDown={() => startZoom(zoomOut)}
+            onClick={zoomOut}
             onMouseUp={stopZoom}
             onMouseLeave={stopZoom}
           >

--- a/client/src/components/Sidebar/Overview.tsx
+++ b/client/src/components/Sidebar/Overview.tsx
@@ -44,6 +44,7 @@ export default function Overview() {
     navigate(`/mindmap/${getLatestMindMap()}?mode=${selectMode}`);
     closeModal();
   }
+
   function navigateToNewMindMap() {
     handleConnection(navigate, "listview", isAuthenticated);
     closeModal();

--- a/client/src/konva_mindmap/components/NodeTool.tsx
+++ b/client/src/konva_mindmap/components/NodeTool.tsx
@@ -1,0 +1,33 @@
+import { Location } from "@/konva_mindmap/types/location";
+import { Button } from "@headlessui/react";
+import { FaAddressBook, FaPencilAlt, FaRegTrashAlt } from "react-icons/fa";
+import { TbCirclePlus2 } from "react-icons/tb";
+import { Html } from "react-konva-utils";
+
+type NodeToolProps = {
+  offset: Location;
+  visible: boolean;
+  handleEdit: () => void;
+  handleAdd: () => void;
+  handleDelete: () => void;
+};
+export default function NodeTool({ offset, visible, handleEdit, handleAdd, handleDelete }: NodeToolProps) {
+  const visibility = visible ? "" : "hidden";
+  return (
+    <Html groupProps={{ offset: { x: offset.x, y: offset.y }, visible: visible }}>
+      <div
+        className={`${visibility} flex w-28 justify-center gap-3 rounded-full border border-grayscale-300 bg-white p-3`}
+      >
+        <Button className="group" onClick={handleEdit}>
+          <FaPencilAlt className="h-5 w-5 cursor-pointer fill-black group-hover:fill-grayscale-400" />
+        </Button>
+        <Button className="group" onClick={handleAdd}>
+          <TbCirclePlus2 className="h-5 w-5 cursor-pointer stroke-black group-hover:stroke-grayscale-400" />
+        </Button>
+        <Button className="group" onClick={handleDelete}>
+          <FaRegTrashAlt className="h-5 w-5 cursor-pointer fill-black group-hover:fill-grayscale-400" />
+        </Button>
+      </div>
+    </Html>
+  );
+}

--- a/client/src/konva_mindmap/components/selectionRect.tsx
+++ b/client/src/konva_mindmap/components/selectionRect.tsx
@@ -5,7 +5,7 @@ import { RefObject, useEffect, useRef, useState } from "react";
 import { Rect } from "react-konva";
 
 export default function SelectionRect({ stage, dragmode }: { stage: RefObject<Konva.Stage>; dragmode: boolean }) {
-  const { groupSelect, groupRelease } = useNodeListContext();
+  const { groupSelect, groupRelease, selectedNode, selectNode } = useNodeListContext();
   const [rectOption, setRectOption] = useState({
     visible: false,
     x: 0,
@@ -34,6 +34,9 @@ export default function SelectionRect({ stage, dragmode }: { stage: RefObject<Ko
 
     const handleMouseDown = (e) => {
       if (dragmode || e.target.getParent()?.attrs.name === "node") return;
+      if (!e.target.getParent() || e.target.getParent().attrs.id !== selectedNode.nodeId) {
+        selectNode({});
+      }
       const pos = currentStage.getRelativePointerPosition();
       setStartPoint({ x: pos.x, y: pos.y });
 

--- a/client/src/konva_mindmap/utils/nodeAttrs.ts
+++ b/client/src/konva_mindmap/utils/nodeAttrs.ts
@@ -14,3 +14,6 @@ export const CONNECTED_LINE_TO = (depth: number) => NODE_DEFAULT_SIZE - depth * 
 
 //TEXT
 export const TEXT_FONT_SIZE = 20;
+
+export const TOOL_OFFSET_X = NODE_DEFAULT_SIZE - 30;
+export const TOOL_OFFSET_Y = (radius: number) => NODE_DEFAULT_SIZE + radius - 20;

--- a/client/src/types/Node.ts
+++ b/client/src/types/Node.ts
@@ -14,9 +14,9 @@ export type Node = {
 export type NodeData = Record<number, Node>;
 
 export type SelectedNode = {
-  nodeId: number;
-  parentNodeId: number;
-  addTo: "canvas" | "list";
+  nodeId?: number;
+  parentNodeId?: number;
+  addTo?: "canvas" | "list";
 };
 
 export type NodeProps = {


### PR DESCRIPTION
#156 마인드맵을 클릭하면 노드 위에 툴을 통해서도 수정, 삭제, 추가가 가능하다 
## 작업 내용
- 마인드맵 선택 시 노드 위에 툴들이 뜰 수 있도록 하여 사용작가 보다 편하게 이용할 수 있도록 하였습니다.
<img width="163" alt="스크린샷 2024-11-29 오전 3 36 26" src="https://github.com/user-attachments/assets/a3151cf3-6631-4f9e-ba58-170f69be9f7b">
- 마인드맵 안의 요소가 캔버스 바깥을 나갔음에도 보이는 문제를 해결했습니다.
- 확대와 축소 버튼의 경우 한번만 클릭해도 작동할 수 있도록 개선했습니다.

## 논의하고 싶은 내용
마인드맵 안의 요소가 캔버스 바깥을 나갔음에도 보이는 문제를 해결했지만, 아직까지 오른쪽에서 노드를 추가했을 때는 갑자기 캔버스가 줄어드는 문제가 있었습니다. 아직 원인 파악이 안돼서 확인 중입니다...