### PR TITLE
[Feature-6-11-fe]대시보드를 통해 회원과 비회원 모두 권한 관리를 갱신하며, 권한에 따라 마인드맵 상에서 가질 수 있는 수정 범위가 달라진다.

### DIFF
--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -1,11 +1,9 @@
 import { instance } from "@/api";
 import { TokenRefresh, User } from "@/types/auth";
-import { setToken } from "@/utils/localstorage";
 
 export const tokenRefresh = async (): Promise<TokenRefresh> => {
   const { data } = await instance.post("/auth/refresh", {}, { withCredentials: true });
-  setToken(data.accessToken);
-  return;
+  return data;
 };
 
 export const getUser = async (): Promise<User> => {

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -1,7 +1,7 @@
 import { tokenRefresh } from "@/api/auth";
 import { logOnDev } from "@/utils/logging";
-import { getToken } from "@/utils/localstorage";
 import axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from "axios";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 export const instance = axios.create({
   baseURL: import.meta.env.VITE_APP_API_SERVER_BASE_URL,
@@ -23,7 +23,7 @@ declare module "axios" {
 instance.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   const { method, baseURL, url } = config;
   logOnDev(`🚀 [API Request] ${method?.toUpperCase()} ${baseURL} ${url}`);
-  const accessToken = getToken();
+  const accessToken = useConnectionStore.getState().token;
 
   config.headers["Content-Type"] = "application/json";
   config.headers["Authorization"] = `Bearer ${accessToken}`;
@@ -54,7 +54,8 @@ instance.interceptors.response.use(
           originalRequest._retry = true;
 
           const newAccessToken = await tokenRefresh();
-          originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
+          useConnectionStore.getState().tokenRefresh(newAccessToken.accessToken);
+          originalRequest.headers["Authorization"] = `Bearer ${newAccessToken.accessToken}`;
 
           return instance(originalRequest);
         }

--- a/client/src/components/Authorize/index.tsx
+++ b/client/src/components/Authorize/index.tsx
@@ -1,13 +1,8 @@
-import { tokenRefresh } from "@/api/auth";
-import Spinner from "@/components/common/Spinner";
 import { useTokenRefresh } from "@/hooks/useTokenRefresh";
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 export default function Authorize() {
-  const [searchParams] = useSearchParams();
-  // const loginSuccess = searchParams.get("success");
   const navigate = useNavigate();
 
   const refresh = useTokenRefresh();
@@ -17,9 +12,6 @@ export default function Authorize() {
       onSuccess: () => navigate("/"),
       onError: () => navigate("/error"),
     });
-    // if (loginSuccess === "true") {
-    // navigate("/");
-    // }
   }, [navigate]);
 
   return <p className="text-white">Authenticating</p>;

--- a/client/src/components/Authorize/index.tsx
+++ b/client/src/components/Authorize/index.tsx
@@ -1,15 +1,19 @@
 import { useTokenRefresh } from "@/hooks/useTokenRefresh";
+import { useConnectionStore } from "@/store/useConnectionStore";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 export default function Authorize() {
   const navigate = useNavigate();
-
+  const updateToken = useConnectionStore((state) => state.tokenRefresh);
   const refresh = useTokenRefresh();
 
   useEffect(() => {
     refresh.mutate(undefined, {
-      onSuccess: () => navigate("/"),
+      onSuccess: (response) => {
+        updateToken(response.accessToken);
+        navigate("/");
+      },
       onError: () => navigate("/error"),
     });
   }, [navigate]);

--- a/client/src/components/Dashboard/GuestNewMindMapModal.tsx
+++ b/client/src/components/Dashboard/GuestNewMindMapModal.tsx
@@ -3,13 +3,12 @@ import { Button } from "@headlessui/react";
 import { createPortal } from "react-dom";
 import warnIcon from "@/assets/warning.png";
 import { useNavigate } from "react-router-dom";
-import { useSocketStore } from "@/store/useSocketStore";
-import { useAuthStore } from "@/store/useAuthStore";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 export default function GuestNewMindMapModal({ open, closeModal, openLogin }) {
   const navigate = useNavigate();
-  const handleConnection = useSocketStore((state) => state.handleConnection);
-  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const createConnection = useConnectionStore((state) => state.createConnection);
+  const isAuthenticated = useConnectionStore((state) => state.isAuthenticated);
 
   return (
     <>
@@ -25,7 +24,7 @@ export default function GuestNewMindMapModal({ open, closeModal, openLogin }) {
             </Button>
             <Button
               className="w-full rounded-md bg-grayscale-400 p-2 transition hover:brightness-90"
-              onClick={() => handleConnection(navigate, "listview", isAuthenticated)}
+              onClick={() => createConnection(navigate, "listview", isAuthenticated)}
             >
               그냥 할게요
             </Button>

--- a/client/src/components/Dashboard/GuestNewMindMapModal.tsx
+++ b/client/src/components/Dashboard/GuestNewMindMapModal.tsx
@@ -8,7 +8,6 @@ import { useConnectionStore } from "@/store/useConnectionStore";
 export default function GuestNewMindMapModal({ open, closeModal, openLogin }) {
   const navigate = useNavigate();
   const createConnection = useConnectionStore((state) => state.createConnection);
-  const isAuthenticated = useConnectionStore((state) => state.isAuthenticated);
 
   return (
     <>
@@ -24,7 +23,7 @@ export default function GuestNewMindMapModal({ open, closeModal, openLogin }) {
             </Button>
             <Button
               className="w-full rounded-md bg-grayscale-400 p-2 transition hover:brightness-90"
-              onClick={() => createConnection(navigate, "listview", isAuthenticated)}
+              onClick={() => createConnection(navigate, "listview")}
             >
               그냥 할게요
             </Button>

--- a/client/src/components/Dashboard/MindMapInfoItem.tsx
+++ b/client/src/components/Dashboard/MindMapInfoItem.tsx
@@ -4,12 +4,11 @@ import { Button } from "@headlessui/react";
 import extractDate from "@/utils/extractDate";
 import DeleteMindMapModal from "../DeleteMindMapModal";
 import { createPortal } from "react-dom";
-import { useAuthStore } from "@/store/useAuthStore";
 import { FaRegTrashAlt } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import { useDeleteMindMap } from "@/api/fetchHooks/useDeleteMindMap";
 import { DashBoard } from "@/konva_mindmap/types/dashboard";
-import { useSocketStore } from "@/store/useSocketStore";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 interface MindMapInfoItemProps {
   data: DashBoard;
@@ -18,14 +17,14 @@ interface MindMapInfoItemProps {
 
 export default function MindMapInfoItem({ data, index }: MindMapInfoItemProps) {
   const { open, openModal, closeModal } = useModal();
-  const { id } = useAuthStore();
   const keywordData = data.keyword.slice(0, 4);
   const navigate = useNavigate();
   const mutation = useDeleteMindMap({
     mindMapId: data.id.toString(),
     onError: (error) => console.log(error),
   });
-  const getConnection = useSocketStore((state) => state.getConnection);
+  const id = useConnectionStore((state) => state.id);
+  const getConnection = useConnectionStore((state) => state.getConnection);
 
   const ownerCheck = id === data.ownerId;
 

--- a/client/src/components/Dashboard/NoMindMap.tsx
+++ b/client/src/components/Dashboard/NoMindMap.tsx
@@ -1,14 +1,13 @@
-import { useAuthStore } from "@/store/useAuthStore";
-import { useSocketStore } from "@/store/useSocketStore";
 import { Button } from "@headlessui/react";
 import { FaPlus } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import cloud from "@/assets/dashbordIcon.png";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 export default function NoMindMap() {
-  const handleConnection = useSocketStore((state) => state.handleConnection);
+  const handleConnection = useConnectionStore((state) => state.createConnection);
   const navigate = useNavigate();
-  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const isAuthenticated = useConnectionStore((state) => state.isAuthenticated);
   return (
     <div className="mb-20 flex h-full w-full flex-col items-center justify-center rounded-[20px] bg-grayscale-700 pb-10">
       <p className="whitespace-pre-line text-center text-3xl font-bold">

--- a/client/src/components/Dashboard/NoMindMap.tsx
+++ b/client/src/components/Dashboard/NoMindMap.tsx
@@ -5,9 +5,8 @@ import cloud from "@/assets/dashbordIcon.png";
 import { useConnectionStore } from "@/store/useConnectionStore";
 
 export default function NoMindMap() {
-  const handleConnection = useConnectionStore((state) => state.createConnection);
+  const createConnection = useConnectionStore((state) => state.createConnection);
   const navigate = useNavigate();
-  const isAuthenticated = useConnectionStore((state) => state.isAuthenticated);
   return (
     <div className="mb-20 flex h-full w-full flex-col items-center justify-center rounded-[20px] bg-grayscale-700 pb-10">
       <p className="whitespace-pre-line text-center text-3xl font-bold">
@@ -18,7 +17,7 @@ export default function NoMindMap() {
       <img className="w-[300px]" src={cloud} alt="로그인 후 마인드맵 없을 때 아이콘" />
       <Button
         className="group mt-4 flex w-[300px] items-center justify-center gap-3 rounded-[10px] bg-bm-blue px-10 py-2 transition hover:brightness-90"
-        onClick={() => handleConnection(navigate, "textupload", isAuthenticated)}
+        onClick={() => createConnection(navigate, "textupload")}
       >
         새로운 마인드맵 만들기
       </Button>

--- a/client/src/components/Dashboard/UserDashBoard.tsx
+++ b/client/src/components/Dashboard/UserDashBoard.tsx
@@ -1,8 +1,7 @@
 import MindMapInfoItem from "./MindMapInfoItem";
-import addIcon from "@/assets/whitePlus.png";
 import searchIcon from "@/assets/search.png";
 import { Button, Input } from "@headlessui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FaPlus } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import useDashBoard from "@/api/fetchHooks/useDashBoard";
@@ -14,7 +13,13 @@ export default function UserDashBoard() {
   const [searchContent, setSearchContent] = useState("");
   const navigate = useNavigate();
   const createConnection = useConnectionStore((state) => state.createConnection);
-  const isAuthenticated = useConnectionStore((state) => state.isAuthenticated);
+  const updateOwnedMindMap = useConnectionStore((state) => state.updateOwnedMindMap);
+
+  useEffect(() => {
+    if (data.length) {
+      updateOwnedMindMap(data);
+    }
+  }, [data]);
 
   function searchData(content: string) {
     if (!data) return [];
@@ -41,7 +46,7 @@ export default function UserDashBoard() {
       <div className="absolute bottom-8 right-8">
         <Button
           className="flex items-center justify-center gap-2 rounded-xl bg-bm-blue px-5 py-3 transition hover:brightness-90"
-          onClick={() => createConnection(navigate, "textupload", isAuthenticated)}
+          onClick={() => createConnection(navigate, "textupload")}
         >
           <FaPlus className="h-4 w-4" />
           <p>새로운 마인드맵 만들기</p>

--- a/client/src/components/Dashboard/UserDashBoard.tsx
+++ b/client/src/components/Dashboard/UserDashBoard.tsx
@@ -5,17 +5,16 @@ import { Button, Input } from "@headlessui/react";
 import { useState } from "react";
 import { FaPlus } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
-import { useSocketStore } from "@/store/useSocketStore";
-import { useAuthStore } from "@/store/useAuthStore";
 import useDashBoard from "@/api/fetchHooks/useDashBoard";
 import NoMindMap from "@/components/Dashboard/NoMindMap";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 export default function UserDashBoard() {
   const { data } = useDashBoard();
   const [searchContent, setSearchContent] = useState("");
   const navigate = useNavigate();
-  const handleConnection = useSocketStore((state) => state.handleConnection);
-  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const createConnection = useConnectionStore((state) => state.createConnection);
+  const isAuthenticated = useConnectionStore((state) => state.isAuthenticated);
 
   function searchData(content: string) {
     if (!data) return [];
@@ -42,7 +41,7 @@ export default function UserDashBoard() {
       <div className="absolute bottom-8 right-8">
         <Button
           className="flex items-center justify-center gap-2 rounded-xl bg-bm-blue px-5 py-3 transition hover:brightness-90"
-          onClick={() => handleConnection(navigate, "textupload", isAuthenticated)}
+          onClick={() => createConnection(navigate, "textupload", isAuthenticated)}
         >
           <FaPlus className="h-4 w-4" />
           <p>새로운 마인드맵 만들기</p>

--- a/client/src/components/Dashboard/index.tsx
+++ b/client/src/components/Dashboard/index.tsx
@@ -3,10 +3,10 @@ import GuestDashBoard from "./GuestDashBoard";
 import UserDashBoard from "./UserDashBoard";
 
 export default function DashBoard() {
-  const loggedIn = useConnectionStore((state) => state.isAuthenticated);
+  const loggedIn = useConnectionStore((state) => state.token);
   return (
     <>
-      <section className="relative w-full">{loggedIn ? <UserDashBoard /> : <GuestDashBoard />}</section>
+      <section className="relative w-full">{!!loggedIn ? <UserDashBoard /> : <GuestDashBoard />}</section>
     </>
   );
 }

--- a/client/src/components/Dashboard/index.tsx
+++ b/client/src/components/Dashboard/index.tsx
@@ -1,9 +1,9 @@
+import { useConnectionStore } from "@/store/useConnectionStore";
 import GuestDashBoard from "./GuestDashBoard";
 import UserDashBoard from "./UserDashBoard";
-import { useAuthStore } from "@/store/useAuthStore";
 
 export default function DashBoard() {
-  const loggedIn = useAuthStore((state) => state.isAuthenticated);
+  const loggedIn = useConnectionStore((state) => state.isAuthenticated);
   return (
     <>
       <section className="relative w-full">{loggedIn ? <UserDashBoard /> : <GuestDashBoard />}</section>

--- a/client/src/components/MindMapCanvas/CanvasButtons.tsx
+++ b/client/src/components/MindMapCanvas/CanvasButtons.tsx
@@ -2,12 +2,12 @@ import DeleteConfirmModal from "@/components/MindMapCanvas/DeleteConfirmModal";
 import useModal from "@/hooks/useModal";
 import { findRootNodeKey } from "@/konva_mindmap/utils/findRootNodeKey";
 import { useNodeListContext } from "@/store/NodeListProvider";
-import { useSocketStore } from "@/store/useSocketStore";
+import { useConnectionStore } from "@/store/useConnectionStore";
 import { Button } from "@headlessui/react";
 import { createPortal } from "react-dom";
 
 export default function CanvasButtons({ handleReArrange, handleCenterMove, showMinutes, handleShowMinutes }) {
-  const { handleSocketEvent } = useSocketStore();
+  const handleSocketEvent = useConnectionStore((state) => state.handleSocketEvent);
   const { data, overrideNodeData } = useNodeListContext();
   const { open, openModal, closeModal } = useModal();
   const rootKey = findRootNodeKey(data);

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -13,8 +13,8 @@ import SelectionRect from "@/konva_mindmap/components/selectionRect";
 import DrawMindMap from "@/konva_mindmap/components/DrawMindMap";
 import ShowShortCut from "./ShowShortCut";
 import { findRootNodeKey } from "@/konva_mindmap/utils/findRootNodeKey";
-import { useSocketStore } from "@/store/useSocketStore";
 import { showNewNode } from "@/konva_mindmap/events/addNode";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
   const {
@@ -34,7 +34,7 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
   const registerLayer = useCollisionDetection(data, updateNode);
   const stageRef = useRef();
   const { registerStageRef } = useStageStore();
-  const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
+  const handleSocketEvent = useConnectionStore((state) => state.handleSocketEvent);
 
   const rootKey = findRootNodeKey(data);
 

--- a/client/src/components/MindMapHeader/Profile.tsx
+++ b/client/src/components/MindMapHeader/Profile.tsx
@@ -9,7 +9,7 @@ import { useConnectionStore } from "@/store/useConnectionStore";
 export default function Profile() {
   const { open: loginModal, openModal: openLoginModal, closeModal: closeLoginModal } = useModal();
   const { open: profileModal, openModal: openProfileModal, closeModal: closeProfileModal } = useModal();
-  const isAuthenticated = useConnectionStore((state) => state.isAuthenticated);
+  const isAuthenticated = useConnectionStore((state) => state.token);
 
   function handleProfileModal() {
     if (isAuthenticated) {

--- a/client/src/components/MindMapHeader/Profile.tsx
+++ b/client/src/components/MindMapHeader/Profile.tsx
@@ -1,19 +1,18 @@
 import LoginModal from "@/components/LoginModal";
-import profile from "@/assets/profile.png";
 import { Button } from "@headlessui/react";
 import { createPortal } from "react-dom";
-import { useAuthStore } from "@/store/useAuthStore";
 import useModal from "@/hooks/useModal";
 import ProfileModal from "@/components/MindMapHeader/ProfileModal";
 import { FaUserCircle } from "react-icons/fa";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 export default function Profile() {
   const { open: loginModal, openModal: openLoginModal, closeModal: closeLoginModal } = useModal();
   const { open: profileModal, openModal: openProfileModal, closeModal: closeProfileModal } = useModal();
-  const auth = useAuthStore();
-  
+  const isAuthenticated = useConnectionStore((state) => state.isAuthenticated);
+
   function handleProfileModal() {
-    if (auth.isAuthenticated) {
+    if (isAuthenticated) {
       openProfileModal();
       return;
     }

--- a/client/src/components/MindMapHeader/ProfileModal.tsx
+++ b/client/src/components/MindMapHeader/ProfileModal.tsx
@@ -1,5 +1,5 @@
 import profileIcon from "@/assets/profile.png";
-import { useAuthStore } from "@/store/useAuthStore";
+import { useConnectionStore } from "@/store/useConnectionStore";
 import { Button } from "@headlessui/react";
 import { useEffect, useRef } from "react";
 import { FaUserCircle } from "react-icons/fa";
@@ -9,12 +9,14 @@ type ProfileModalProps = {
   close: () => void;
 };
 export default function ProfileModal({ open, close }: ProfileModalProps) {
-  const auth = useAuthStore();
+  const logout = useConnectionStore((state) => state.logout);
+  const email = useConnectionStore((state) => state.email);
+  const name = useConnectionStore((state) => state.name);
   const modalRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
 
   const handleLogout = () => {
-    auth.logout();
+    logout();
     navigate("/");
     close();
   };
@@ -44,8 +46,8 @@ export default function ProfileModal({ open, close }: ProfileModalProps) {
         >
           <FaUserCircle className="my-5 h-11 w-11" color="#93C5FD" />
           <div className="w-full px-5 py-0 text-center">
-            <p>{auth.name}</p>
-            <p className="text-sm text-grayscale-300">{auth.email}</p>
+            <p>{name}</p>
+            <p className="text-sm text-grayscale-300">{email}</p>
           </div>
           <Button className="w-full p-3 px-5 text-sm transition hover:brightness-75" onClick={handleLogout}>
             로그아웃

--- a/client/src/components/MindMapHeader/index.tsx
+++ b/client/src/components/MindMapHeader/index.tsx
@@ -3,7 +3,7 @@ import MindMapHeaderButtons from "@/components/MindMapHeader/MindMapHeaderButton
 import Profile from "@/components/MindMapHeader/Profile";
 import useAuth from "@/hooks/useAuth";
 import { useNodeListContext } from "@/store/NodeListProvider";
-import { useSocketStore } from "@/store/useSocketStore";
+import { useConnectionStore } from "@/store/useConnectionStore";
 import { Input } from "@headlessui/react";
 import { useState } from "react";
 import { createPortal } from "react-dom";
@@ -13,9 +13,9 @@ export default function MindMapHeader() {
   const { title, updateTitle } = useNodeListContext();
   const { isLoading } = useAuth();
   const [editMode, setEditMode] = useState(false);
-  const handleSocketEvent = useSocketStore((state) => state.handleSocketEvent);
+  const handleSocketEvent = useConnectionStore((state) => state.handleSocketEvent);
   const [editTitle, setEditTitle] = useState(title);
-  const role = useSocketStore((state) => state.role);
+  const role = useConnectionStore((state) => state.currentRole);
 
   function handleInputBlur() {
     if (!title.length) return;

--- a/client/src/components/MindMapMainSection/index.tsx
+++ b/client/src/components/MindMapMainSection/index.tsx
@@ -2,11 +2,11 @@ import MindMapHeader from "@/components/MindMapHeader";
 import MindMapView from "@/components/MindMapMainSection/MindMapView";
 import useSection from "@/hooks/useSection";
 import { useNodeListContext } from "@/store/NodeListProvider";
-import { useSocketStore } from "@/store/useSocketStore";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import ToastContainer from "../common/Toast/ToastContainer";
 import useAuth from "@/hooks/useAuth";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 const modeView = {
   voiceupload: "음성 파일 업로드",
@@ -18,9 +18,10 @@ export default function MindMapMainSection() {
   const mode = useSection().searchParams.get("mode") as keyof typeof modeView;
   const { mindMapId } = useParams<{ mindMapId: string }>();
   const { updateMindMapId } = useNodeListContext();
-  const { connectSocket, disconnectSocket, wsError } = useSocketStore();
+  const connectSocket = useConnectionStore((state) => state.connectSocket);
+  const disconnectSocket = useConnectionStore((state) => state.disconnectSocket);
+  const wsError = useConnectionStore((state) => state.wsError);
   const [toasts, setToasts] = useState([]);
-  const { accessToken } = useAuth();
 
   useEffect(() => {
     if (wsError.length > 0)
@@ -32,7 +33,7 @@ export default function MindMapMainSection() {
 
   useEffect(() => {
     if (mindMapId) {
-      connectSocket(mindMapId, accessToken);
+      connectSocket(mindMapId);
       updateMindMapId(mindMapId);
     }
     return () => {

--- a/client/src/components/Minutes/Tiptap/index.tsx
+++ b/client/src/components/Minutes/Tiptap/index.tsx
@@ -38,10 +38,9 @@ export default function Tiptap() {
     ],
     content: content,
     onUpdate({ editor }) {
-      if (!role || role === "editor") return;
+      if (role === "editor") return;
       handleChangeContent(editor);
     },
-    editable: role === "owner",
   });
 
   function handleChangeContent(editor) {
@@ -57,6 +56,10 @@ export default function Tiptap() {
       1500,
     );
   }
+
+  useEffect(() => {
+    editor.setOptions({ editable: role === "owner" });
+  }, [role]);
 
   useEffect(() => {
     if (editor && content) {

--- a/client/src/components/Minutes/Tiptap/index.tsx
+++ b/client/src/components/Minutes/Tiptap/index.tsx
@@ -10,14 +10,14 @@ import { Indent } from "./utils/indent";
 import CustomCodeBlockLowlight from "./utils/codeBlockIndent";
 import Placeholder from "@tiptap/extension-placeholder";
 import { useNodeListContext } from "@/store/NodeListProvider";
-import { useSocketStore } from "@/store/useSocketStore";
 import { throttle } from "@/konva_mindmap/utils/throttle";
 import { useEffect } from "react";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 export default function Tiptap() {
   const { content, updateContent } = useNodeListContext();
-  const handleSocketEvent = useSocketStore((state) => state.handleSocketEvent);
-  const role = useSocketStore((state) => state.role);
+  const handleSocketEvent = useConnectionStore((state) => state.handleSocketEvent);
+  const role = useConnectionStore((state) => state.currentRole);
 
   const editor = useEditor({
     extensions: [

--- a/client/src/components/Sidebar/Overview.tsx
+++ b/client/src/components/Sidebar/Overview.tsx
@@ -20,7 +20,6 @@ export default function Overview() {
   const { getmode, handleViewMode } = useSection();
   const socket = useConnectionStore((state) => state.socket);
   const createConnection = useConnectionStore((state) => state.createConnection);
-  const isAuthenticated = useConnectionStore((state) => state.isAuthenticated);
   const { open, closeModal, openModal } = useModal();
   const [selectMode, setSelcetMode] = useState<ViewMode>("listview");
 
@@ -32,7 +31,7 @@ export default function Overview() {
 
     const latestMindMap = getLatestMindMap();
     if (!latestMindMap) {
-      createConnection(navigate, mode, isAuthenticated);
+      createConnection(navigate, mode);
       return;
     }
     openModal();
@@ -46,7 +45,7 @@ export default function Overview() {
   }
 
   function navigateToNewMindMap() {
-    createConnection(navigate, "listview", isAuthenticated);
+    createConnection(navigate, "listview");
     closeModal();
   }
 

--- a/client/src/components/Sidebar/Overview.tsx
+++ b/client/src/components/Sidebar/Overview.tsx
@@ -2,8 +2,6 @@ import aiIcon from "@/assets/ai.png";
 import OverviewButton from "@/components/Sidebar/OverviewButton";
 import useSection from "@/hooks/useSection";
 import { useNavigate } from "react-router-dom";
-import { useSocketStore } from "@/store/useSocketStore";
-import { useAuthStore } from "@/store/useAuthStore";
 import { getLatestMindMap } from "@/utils/localstorage";
 import useModal from "@/hooks/useModal";
 import { createPortal } from "react-dom";
@@ -14,13 +12,15 @@ import { FaListUl } from "react-icons/fa";
 import { FaFileAlt } from "react-icons/fa";
 import { FaFileAudio } from "react-icons/fa6";
 import { RiRobot3Line } from "react-icons/ri";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 type ViewMode = "listview" | "voiceupload" | "textupload";
 export default function Overview() {
   const navigate = useNavigate();
   const { getmode, handleViewMode } = useSection();
-  const { socket, handleConnection } = useSocketStore();
-  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const socket = useConnectionStore((state) => state.socket);
+  const createConnection = useConnectionStore((state) => state.createConnection);
+  const isAuthenticated = useConnectionStore((state) => state.isAuthenticated);
   const { open, closeModal, openModal } = useModal();
   const [selectMode, setSelcetMode] = useState<ViewMode>("listview");
 
@@ -32,7 +32,7 @@ export default function Overview() {
 
     const latestMindMap = getLatestMindMap();
     if (!latestMindMap) {
-      handleConnection(navigate, mode, isAuthenticated);
+      createConnection(navigate, mode, isAuthenticated);
       return;
     }
     openModal();
@@ -46,7 +46,7 @@ export default function Overview() {
   }
 
   function navigateToNewMindMap() {
-    handleConnection(navigate, "listview", isAuthenticated);
+    createConnection(navigate, "listview", isAuthenticated);
     closeModal();
   }
 

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,19 +1,17 @@
 import { getUser } from "@/api/auth";
-import { useAuthStore } from "@/store/useAuthStore";
-import { getToken } from "@/utils/localstorage";
+import { useConnectionStore } from "@/store/useConnectionStore";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 export default function useAuth() {
-  const accessToken = getToken();
-  const auth = useAuthStore();
+  const isAuthenticated = useConnectionStore((state) => state.isAuthenticated);
   const navigate = useNavigate();
 
   const { isLoading, isError } = useQuery({
     queryKey: ["user"],
     queryFn: getUser,
-    enabled: !!(accessToken || auth.isAuthenticated),
+    enabled: isAuthenticated,
   });
 
   useEffect(() => {
@@ -21,5 +19,5 @@ export default function useAuth() {
       navigate("/error");
     }
   }, [isError]);
-  return { isLoading, accessToken };
+  return { isLoading };
 }

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -5,13 +5,13 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 export default function useAuth() {
-  const isAuthenticated = useConnectionStore((state) => state.isAuthenticated);
+  const isAuthenticated = useConnectionStore((state) => state.token);
   const navigate = useNavigate();
 
   const { isLoading, isError } = useQuery({
     queryKey: ["user"],
     queryFn: getUser,
-    enabled: isAuthenticated,
+    enabled: !!isAuthenticated,
   });
 
   useEffect(() => {

--- a/client/src/hooks/useHistoryState.ts
+++ b/client/src/hooks/useHistoryState.ts
@@ -1,10 +1,10 @@
-import { useSocketStore } from "@/store/useSocketStore";
+import { useConnectionStore } from "@/store/useConnectionStore";
 import { useState, useCallback } from "react";
 
 export default function useHistoryState<T>(data: string) {
   const [history, setHistory] = useState([data]);
   const [pointer, setPointer] = useState(0);
-  const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
+  const handleSocketEvent = useConnectionStore((state) => state.handleSocketEvent);
 
   const saveHistory = useCallback(
     (data: string) => {

--- a/client/src/hooks/useNodeActions.ts
+++ b/client/src/hooks/useNodeActions.ts
@@ -1,7 +1,7 @@
 import { addNode } from "@/konva_mindmap/events/addNode";
 import { deleteNodes } from "@/konva_mindmap/events/deleteNode";
 import { useNodeListContext } from "@/store/NodeListProvider";
-import { useSocketStore } from "@/store/useSocketStore";
+import { useConnectionStore } from "@/store/useConnectionStore";
 import { ChangeEvent, KeyboardEvent, useEffect, useState } from "react";
 
 export default function useNodeActions(nodeId: number, content: string) {
@@ -9,7 +9,7 @@ export default function useNodeActions(nodeId: number, content: string) {
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [keyword, setKeyword] = useState(content);
   const { data, updateNode, saveHistory, overrideNodeData } = useNodeListContext();
-  const handleSocketEvent = useSocketStore((state) => state.handleSocketEvent);
+  const handleSocketEvent = useConnectionStore((state) => state.handleSocketEvent);
 
   useEffect(() => {
     setKeyword(content);

--- a/client/src/konva_mindmap/components/EditableText.tsx
+++ b/client/src/konva_mindmap/components/EditableText.tsx
@@ -2,8 +2,8 @@ import { Text } from "react-konva";
 import { useEffect, useState } from "react";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import EditableTextInput from "@/konva_mindmap/components/EditableTextInput";
-import { useSocketStore } from "@/store/useSocketStore";
 import { TEXT_FONT_SIZE } from "@/konva_mindmap/utils/nodeAttrs";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 interface EditableTextProps {
   id: number;
@@ -28,7 +28,8 @@ export default function EditableText({
   const originalContent = text;
   const [keyword, setKeyword] = useState(originalContent);
   const { data, updateNode, saveHistory } = useNodeListContext();
-  const { handleSocketEvent, currentJobStatus } = useSocketStore();
+  const handleSocketEvent = useConnectionStore((state) => state.handleSocketEvent);
+  const currentJobStatus = useConnectionStore((state) => state.currentJobStatus);
 
   useEffect(() => {
     setKeyword(text);

--- a/client/src/konva_mindmap/components/MindMapNode.tsx
+++ b/client/src/konva_mindmap/components/MindMapNode.tsx
@@ -4,7 +4,6 @@ import { NodeProps } from "@/types/Node";
 import { Circle, Group } from "react-konva";
 import { useNodeListContext } from "@/store/NodeListProvider";
 import { useRef, useState } from "react";
-import { useSocketStore } from "@/store/useSocketStore";
 import { checkFollowing, resetSavedOffsets, saveOffsets } from "@/konva_mindmap/utils/following";
 import { colors } from "@/constants/color";
 import Konva from "konva";
@@ -21,6 +20,7 @@ import {
 import NodeTool from "@/konva_mindmap/components/NodeTool";
 import { deleteNodes } from "@/konva_mindmap/events/deleteNode";
 import { showNewNode } from "@/konva_mindmap/events/addNode";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 export default function MindMapNode({ data, parentNode, node, depth, parentRef, dragmode }: NodeProps) {
   if (node.newNode)
@@ -28,7 +28,7 @@ export default function MindMapNode({ data, parentNode, node, depth, parentRef, 
   const nodeRef = useRef<Konva.Group>(null);
   const { saveHistory, updateNode, selectNode, selectedNode, selectedGroup, overrideNodeData, groupRelease } =
     useNodeListContext();
-  const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
+  const handleSocketEvent = useConnectionStore.getState().handleSocketEvent;
   const [isEditing, setIsEditing] = useState(false);
 
   function handleDoubleClick() {

--- a/client/src/konva_mindmap/components/NewNode.tsx
+++ b/client/src/konva_mindmap/components/NewNode.tsx
@@ -2,16 +2,16 @@ import { colors } from "@/constants/color";
 import EditableTextInput from "@/konva_mindmap/components/EditableTextInput";
 import { addNode } from "@/konva_mindmap/events/addNode";
 import { useNodeListContext } from "@/store/NodeListProvider";
-import { useSocketStore } from "@/store/useSocketStore";
 import { NodeProps } from "@/types/Node";
 import { useState } from "react";
 import { Circle, Group } from "react-konva";
 import { NODE_RADIUS, NODE_WIDTH_AND_HEIGHT, TEXT_OFFSET_X, TEXT_OFFSET_Y, TEXT_WIDTH } from "../utils/nodeAttrs";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 export default function NewNode({ data, node, depth }: NodeProps) {
   const { saveHistory, selectedNode, updateNode } = useNodeListContext();
   const [keyword, setKeyword] = useState("제목없음");
-  const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
+  const handleSocketEvent = useConnectionStore.getState().handleSocketEvent;
 
   function handleTextChange(e: React.ChangeEvent<HTMLInputElement>) {
     setKeyword(e.target.value);

--- a/client/src/konva_mindmap/events/addNode.ts
+++ b/client/src/konva_mindmap/events/addNode.ts
@@ -1,8 +1,8 @@
 import { calculateVector } from "@/konva_mindmap/utils/vector";
-import { useSocketStore } from "@/store/useSocketStore";
 import { Node, NodeData, SelectedNode } from "@/types/Node";
 import { findRootNodeKey } from "../utils/findRootNodeKey";
 import { NODE_DEPTH_LIMIT } from "@/constants/node";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 //newNode 플래그를 바꿔 실제 노드들과 상호작용할 수 있는 노드로 변환
 export function addNode(keyword: string, newNodeId: number, updateNode: (id: number, node: Partial<Node>) => void) {
@@ -18,7 +18,7 @@ export function showNewNode(
   selectedNode: SelectedNode,
   overrideNodeData: React.Dispatch<React.SetStateAction<NodeData>>,
 ) {
-  const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
+  const handleSocketEvent = useConnectionStore.getState().handleSocketEvent;
   // 아무 노드도 없을 때는 임의로 id 생성해서 현재는 넣음
   if (!Object.keys(data).length) {
     const newNode = {

--- a/client/src/konva_mindmap/events/deleteNode.ts
+++ b/client/src/konva_mindmap/events/deleteNode.ts
@@ -1,6 +1,6 @@
-import { useSocketStore } from "@/store/useSocketStore";
 import { NodeData } from "@/types/Node";
 import { findRootNodeKey } from "../utils/findRootNodeKey";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 export function deleteNodes(data: string, selectedNodeIds: number | number[], overrideNodeData) {
   const newNodeData: NodeData = JSON.parse(data);
@@ -31,7 +31,7 @@ export function deleteNodes(data: string, selectedNodeIds: number | number[], ov
 
   nodeIds.forEach((nodeId) => deleteNodeAndChildren(nodeId));
 
-  const handleSocketEvent = useSocketStore.getState().handleSocketEvent;
+  const handleSocketEvent = useConnectionStore.getState().handleSocketEvent;
   handleSocketEvent({
     actionType: "updateNode",
     payload: newNodeData,

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -6,10 +6,10 @@ import App from "./App";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import NotFound from "@/components/common/NotFound";
 import AuthorizeCallback from "@/pages/auth";
-import { useAuthStore } from "@/store/useAuthStore";
 import Layout from "@/pages/layout";
 import MindMap from "@/pages/Mindmap";
 import { ErrorBoundary } from "react-error-boundary";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 const router = createBrowserRouter([
   {
@@ -50,8 +50,8 @@ const queryClient = new QueryClient({
 queryClient.getQueryCache().subscribe((event) => {
   if (event?.type === "updated" && event.query.queryKey[0] === "user") {
     const data = event.query.state.data;
-    if (data?.email && data?.name && data?.id) useAuthStore.getState().setUser(data?.email, data?.name, data?.id);
-    else useAuthStore.getState().logout();
+    if (data?.email && data?.name && data?.id) useConnectionStore.getState().setUser(data?.email, data?.name, data?.id);
+    else useConnectionStore.getState().logout();
   }
 });
 

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -1,7 +1,9 @@
 import Spinner from "@/components/common/Spinner";
-import DashBoard from "@/components/Dashboard";
 import Profile from "@/components/MindMapHeader/Profile";
 import useAuth from "@/hooks/useAuth";
+import { lazy, Suspense } from "react";
+
+const DashBoard = lazy(() => import("@/components/Dashboard"));
 
 export default function MainPage() {
   const { isLoading } = useAuth();
@@ -14,7 +16,9 @@ export default function MainPage() {
       <main className="flex h-[90%] w-full flex-col overflow-hidden p-8">
         <p className="p-3 text-2xl font-bold">대시보드</p>
         <div className="relative flex h-[90%] w-full gap-4">
-          <DashBoard />
+          <Suspense fallback={<Spinner />}>
+            <DashBoard />
+          </Suspense>
         </div>
       </main>
     </>

--- a/client/src/pages/layout/index.tsx
+++ b/client/src/pages/layout/index.tsx
@@ -1,13 +1,13 @@
 import NotFound from "@/components/common/NotFound";
 import Sidebar from "@/components/Sidebar";
 import { useSideBar } from "@/store/useSideBar";
-import { useSocketStore } from "@/store/useSocketStore";
 import { ErrorBoundary } from "react-error-boundary";
 import { Outlet } from "react-router-dom";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 export default function Layout() {
   const sidebar = useSideBar();
-  const { connectionStatus } = useSocketStore();
+  const connectionStatus = useConnectionStore((state) => state.connectionStatus);
 
   if (connectionStatus === "error") return <NotFound />;
 

--- a/client/src/store/NodeListProvider.tsx
+++ b/client/src/store/NodeListProvider.tsx
@@ -3,12 +3,11 @@ import useHistoryState from "@/hooks/useHistoryState";
 import { Node, NodeData, SelectedNode } from "@/types/Node";
 import Konva from "konva";
 import { createContext, ReactNode, useContext, useState } from "react";
-
-import { useSocketStore } from "./useSocketStore";
 import { deleteNodes } from "@/konva_mindmap/events/deleteNode";
-import { checkOwner, setLatestMindMap } from "@/utils/localstorage";
+import { setLatestMindMap } from "@/utils/localstorage";
 import useMindMapTitle from "@/hooks/useMindMapTitle";
 import useContent from "@/hooks/useContent";
+import { useConnectionStore } from "@/store/useConnectionStore";
 
 export type NodeListContextType = {
   data: NodeData | null;
@@ -28,7 +27,6 @@ export type NodeListContextType = {
   loading: boolean;
   deleteSelectedNodes: () => void;
   updateMindMapId: (mindMapId: string) => void;
-  isOwner: boolean;
   content: string;
   updateContent: (updatedContent: string) => void;
 };
@@ -50,9 +48,8 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
   const { content, updateContent, initializeContent } = useContent();
   const [loading, setLoading] = useState(true);
   const [mindMapId, setMindMapId] = useState("");
-  const [isOwner, setOwner] = useState(true);
   const { selectedGroup, groupRelease, groupSelect } = useGroupSelect();
-  const socket = useSocketStore((state) => state.socket);
+  const socket = useConnectionStore((state) => state.socket);
 
   socket?.on("joinRoom", (initialData) => {
     setLoading(true);
@@ -144,7 +141,6 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
         loading,
         deleteSelectedNodes,
         updateMindMapId,
-        isOwner,
         content,
         updateContent,
       }}

--- a/client/src/store/createAuthSlice.ts
+++ b/client/src/store/createAuthSlice.ts
@@ -6,9 +6,7 @@ export interface AuthSlice {
   email: null | string;
   name: null | string;
   id: null | number;
-  isAuthenticated: boolean;
   tokenRefresh: (accessToken: string) => void;
-  checkAuthenticated: () => void;
   logout: () => void;
   setUser: (email: string, name: string, id: number) => void;
 }
@@ -18,21 +16,15 @@ export const createAuthSlice: StateCreator<ConnectionStore, [], [], AuthSlice> =
   email: null,
   name: null,
   id: null,
-  isAuthenticated: false,
 
   tokenRefresh: (accessToken: string) => set({ token: accessToken }),
 
-  checkAuthenticated: () => {
-    if (get().token) {
-      set({ isAuthenticated: true });
-    }
-  },
-
   logout: () => {
-    set({ email: null, name: null, isAuthenticated: false, token: "" });
+    set({ email: null, name: null, token: "" });
+    get().resetOwnedMindMap();
   },
 
   setUser: (email: string, name: string, id: number) => {
-    set({ email, name, id, isAuthenticated: true });
+    set({ email, name, id });
   },
 });

--- a/client/src/store/createAuthSlice.ts
+++ b/client/src/store/createAuthSlice.ts
@@ -1,34 +1,38 @@
-import { getToken, removeToken } from "@/utils/localstorage";
-import { create } from "zustand";
+import { ConnectionStore } from "@/types/store";
+import { StateCreator } from "zustand";
 
-type UserStore = {
+export interface AuthSlice {
+  token: string;
   email: null | string;
   name: null | string;
   id: null | number;
   isAuthenticated: boolean;
+  tokenRefresh: (accessToken: string) => void;
   checkAuthenticated: () => void;
   logout: () => void;
   setUser: (email: string, name: string, id: number) => void;
-};
-export const useAuthStore = create<UserStore>((set) => ({
+}
+
+export const createAuthSlice: StateCreator<ConnectionStore, [], [], AuthSlice> = (set, get) => ({
+  token: "",
   email: null,
   name: null,
   id: null,
   isAuthenticated: false,
 
+  tokenRefresh: (accessToken: string) => set({ token: accessToken }),
+
   checkAuthenticated: () => {
-    const accessToken = getToken();
-    if (accessToken) {
+    if (get().token) {
       set({ isAuthenticated: true });
     }
   },
 
   logout: () => {
-    removeToken();
-    set({ email: null, name: null, isAuthenticated: false });
+    set({ email: null, name: null, isAuthenticated: false, token: "" });
   },
 
   setUser: (email: string, name: string, id: number) => {
     set({ email, name, id, isAuthenticated: true });
   },
-}));
+});

--- a/client/src/store/createMindMapOwnershipSlice.ts
+++ b/client/src/store/createMindMapOwnershipSlice.ts
@@ -1,12 +1,13 @@
+import { DashBoard } from "@/konva_mindmap/types/dashboard";
 import { ConnectionStore } from "@/types/store";
 import { StateCreator } from "zustand";
 
 export interface MindMapOwnershipSlice {
   ownedMindMap: string[];
-  ownedMindForGuest: string[];
+  ownedMindMapForGuest: string[];
   addOwnedMindMap: (connectionId: string) => void;
   addOwnedMindMapForGuest: (connectionId: string) => void;
-  updateOwnedMindMap: (mindMaps: string[] | []) => void;
+  updateOwnedMindMap: (mindMaps: DashBoard[]) => void;
   deleteOwnedMindMap: (connectionId: string) => void;
   deleteOwnedMindMapForGuest: (connectionId: string) => void;
   resetOwnedMindMap: () => void;
@@ -17,13 +18,17 @@ export const createMindMapOwnershipSlice: StateCreator<ConnectionStore, [], [], 
   get,
 ) => ({
   ownedMindMap: [],
-  ownedMindForGuest: [],
+  ownedMindMapForGuest: [],
 
   addOwnedMindMap: (connectionId: string) => set((state) => ({ ownedMindMap: [...state.ownedMindMap, connectionId] })),
   addOwnedMindMapForGuest: (connectionId: string) =>
-    set((state) => ({ ownedMindMap: [...state.ownedMindMap, connectionId] })),
+    set((state) => ({ ownedMindMapForGuest: [...state.ownedMindMapForGuest, connectionId] })),
 
-  updateOwnedMindMap: (mindMaps: string[] | []) => set({ ownedMindMap: mindMaps }),
+  updateOwnedMindMap: (mindMaps: DashBoard[]) => {
+    const userId = get().id;
+    const userOwnedMaps = mindMaps.filter((map) => map.ownerId === userId).map((map) => map.connectionId);
+    set({ ownedMindMap: userOwnedMaps });
+  },
 
   deleteOwnedMindMap: (connectionId: string) =>
     set((state) => ({ ownedMindMap: state.ownedMindMap.filter((map) => map !== connectionId) })),

--- a/client/src/store/createMindMapOwnershipSlice.ts
+++ b/client/src/store/createMindMapOwnershipSlice.ts
@@ -1,0 +1,34 @@
+import { ConnectionStore } from "@/types/store";
+import { StateCreator } from "zustand";
+
+export interface MindMapOwnershipSlice {
+  ownedMindMap: string[];
+  ownedMindForGuest: string[];
+  addOwnedMindMap: (connectionId: string) => void;
+  addOwnedMindMapForGuest: (connectionId: string) => void;
+  updateOwnedMindMap: (mindMaps: string[] | []) => void;
+  deleteOwnedMindMap: (connectionId: string) => void;
+  deleteOwnedMindMapForGuest: (connectionId: string) => void;
+  resetOwnedMindMap: () => void;
+}
+
+export const createMindMapOwnershipSlice: StateCreator<ConnectionStore, [], [], MindMapOwnershipSlice> = (
+  set,
+  get,
+) => ({
+  ownedMindMap: [],
+  ownedMindForGuest: [],
+
+  addOwnedMindMap: (connectionId: string) => set((state) => ({ ownedMindMap: [...state.ownedMindMap, connectionId] })),
+  addOwnedMindMapForGuest: (connectionId: string) =>
+    set((state) => ({ ownedMindMap: [...state.ownedMindMap, connectionId] })),
+
+  updateOwnedMindMap: (mindMaps: string[] | []) => set({ ownedMindMap: mindMaps }),
+
+  deleteOwnedMindMap: (connectionId: string) =>
+    set((state) => ({ ownedMindMap: state.ownedMindMap.filter((map) => map !== connectionId) })),
+  deleteOwnedMindMapForGuest: (connectionId: string) =>
+    set((state) => ({ ownedMindMap: state.ownedMindMap.filter((map) => map !== connectionId) })),
+
+  resetOwnedMindMap: () => set({ ownedMindMap: [] }),
+});

--- a/client/src/store/createRoleSlice.ts
+++ b/client/src/store/createRoleSlice.ts
@@ -19,7 +19,7 @@ export const createRoleSlice: StateCreator<ConnectionStore, [], [], RoleSlice> =
       return;
     }
     //비회원 마인드맵 중 확인
-    if (get().ownedMindForGuest.some((ids) => ids === connectionId)) {
+    if (get().ownedMindMapForGuest.some((ids) => ids === connectionId)) {
       get().updateRole("owner");
       return;
     }

--- a/client/src/store/createRoleSlice.ts
+++ b/client/src/store/createRoleSlice.ts
@@ -1,0 +1,28 @@
+import { ConnectionStore } from "@/types/store";
+import { StateCreator } from "zustand";
+
+export interface RoleSlice {
+  currentRole: "owner" | "editor";
+  updateRole: (role: "owner" | "editor") => void;
+  checkRole: (connectionId: string) => void;
+}
+
+export const createRoleSlice: StateCreator<ConnectionStore, [], [], RoleSlice> = (set, get) => ({
+  currentRole: "editor",
+
+  updateRole: (role: "owner" | "editor") => set({ currentRole: role }),
+
+  checkRole: (connectionId: string) => {
+    //회원 마인드맵 중 확인
+    if (get().ownedMindMap.some((ids) => ids === connectionId)) {
+      get().updateRole("owner");
+      return;
+    }
+    //비회원 마인드맵 중 확인
+    if (get().ownedMindForGuest.some((ids) => ids === connectionId)) {
+      get().updateRole("owner");
+      return;
+    }
+    get().updateRole("editor");
+  },
+});

--- a/client/src/store/createSharedSlice.ts
+++ b/client/src/store/createSharedSlice.ts
@@ -3,13 +3,13 @@ import { NavigateFunction } from "react-router-dom";
 import { StateCreator } from "zustand";
 
 export interface SharedSlice {
-  createConnection: (navigate: NavigateFunction, targetMode: string, isAuthenticated: boolean) => void;
+  createConnection: (navigate: NavigateFunction, targetMode: string) => void;
 }
 export const createSharedSlice: StateCreator<ConnectionStore, [], [], SharedSlice> = (set, get) => ({
   createConnection: async (navigate: NavigateFunction, targetMode: string) => {
     try {
       const newMindMapConnectionId = await get().handleConnection();
-      get().isAuthenticated
+      get().token
         ? get().addOwnedMindMap(newMindMapConnectionId)
         : get().addOwnedMindMapForGuest(newMindMapConnectionId);
       navigate(`/mindmap/${newMindMapConnectionId}?mode=${targetMode}`);

--- a/client/src/store/createSharedSlice.ts
+++ b/client/src/store/createSharedSlice.ts
@@ -1,0 +1,20 @@
+import { ConnectionStore } from "@/types/store";
+import { NavigateFunction } from "react-router-dom";
+import { StateCreator } from "zustand";
+
+export interface SharedSlice {
+  createConnection: (navigate: NavigateFunction, targetMode: string, isAuthenticated: boolean) => void;
+}
+export const createSharedSlice: StateCreator<ConnectionStore, [], [], SharedSlice> = (set, get) => ({
+  createConnection: async (navigate: NavigateFunction, targetMode: string) => {
+    try {
+      const newMindMapConnectionId = await get().handleConnection();
+      get().isAuthenticated
+        ? get().addOwnedMindMap(newMindMapConnectionId)
+        : get().addOwnedMindMapForGuest(newMindMapConnectionId);
+      navigate(`/mindmap/${newMindMapConnectionId}?mode=${targetMode}`);
+    } catch (error) {
+      throw error;
+    }
+  },
+});

--- a/client/src/store/createSocketSlice.ts
+++ b/client/src/store/createSocketSlice.ts
@@ -43,11 +43,8 @@ export const createSocketSlice: StateCreator<ConnectionStore, [], [], SocketSlic
       },
       transports: ["websocket"],
     };
-    if (get().isAuthenticated) {
-      options.auth = { token: get().token };
-    } else {
-      get().checkRole(connectionId);
-    }
+
+    get().checkRole(connectionId);
 
     const socket = io(import.meta.env.VITE_APP_SOCKET_SERVER_BASE_URL, options);
 

--- a/client/src/store/createSocketSlice.ts
+++ b/client/src/store/createSocketSlice.ts
@@ -1,5 +1,5 @@
 import { Socket, io } from "socket.io-client";
-import { create } from "zustand";
+import { StateCreator } from "zustand";
 import {
   actionType,
   createNodePayload,
@@ -9,16 +9,14 @@ import {
   updateContentPayload,
 } from "@/types/NodePayload";
 import { createMindmap, getMindMap } from "@/api/mindmap.api";
-import { NavigateFunction } from "react-router-dom";
-import { checkOwner, getToken, setOwner } from "@/utils/localstorage";
+import { ConnectionStore } from "@/types/store";
 
-type SocketState = {
+export type SocketSlice = {
   socket: Socket | null;
-  role: "owner" | "editor" | null;
-  connectSocket: (id: string, token?: string) => void;
+  connectSocket: (id: string) => void;
   disconnectSocket: () => void;
   handleSocketEvent: (props: HandleSocketEventProps) => void;
-  handleConnection: (navigate: NavigateFunction, targetMode: string, isAuthenticated: boolean) => void;
+  handleConnection: () => Promise<string>;
   getConnection: (mindMapId: number, connectionId: string) => void;
   wsError: string[];
   currentJobStatus: string;
@@ -31,25 +29,24 @@ type HandleSocketEventProps = {
   callback?: (response?: any) => void;
 };
 
-export const useSocketStore = create<SocketState>((set, get) => ({
+export const createSocketSlice: StateCreator<ConnectionStore, [], [], SocketSlice> = (set, get) => ({
   socket: null,
   role: null,
   wsError: [],
   currentJobStatus: "",
   connectionStatus: "",
 
-  connectSocket: (id, token) => {
-    if (get().socket) return;
+  connectSocket: (connectionId) => {
     const options: any = {
       query: {
-        connectionId: id,
+        connectionId,
       },
       transports: ["websocket"],
     };
-    if (token) {
-      options.auth = { token };
+    if (get().isAuthenticated) {
+      options.auth = { token: get().token };
     } else {
-      checkOwner(id) ? set({ role: "owner" }) : set({ role: "editor" });
+      get().checkRole(connectionId);
     }
 
     const socket = io(import.meta.env.VITE_APP_SOCKET_SERVER_BASE_URL, options);
@@ -73,7 +70,8 @@ export const useSocketStore = create<SocketState>((set, get) => ({
   disconnectSocket: () => {
     const socket = get().socket;
     if (socket) socket.disconnect();
-    set({ socket: null, role: null });
+    set({ socket: null });
+    get().updateRole("editor");
   },
 
   handleSocketEvent: ({ actionType, payload, callback }: HandleSocketEventProps) => {
@@ -89,16 +87,14 @@ export const useSocketStore = create<SocketState>((set, get) => ({
     });
   },
 
-  handleConnection: async (navigate: NavigateFunction, targetMode: string, isAuthenticated: boolean) => {
+  handleConnection: async () => {
     try {
       const socket = get().socket;
       if (socket) socket.disconnect();
       const response = await createMindmap();
       const newMindMapId = response.data;
-      if (!isAuthenticated) setOwner(newMindMapId);
-      set({ role: "owner" });
-      get().connectSocket(newMindMapId, isAuthenticated ? getToken() : undefined);
-      navigate(`/mindmap/${newMindMapId}?mode=${targetMode}`);
+      get().connectSocket(newMindMapId);
+      return newMindMapId;
     } catch (error) {
       console.error(error);
     }
@@ -109,10 +105,9 @@ export const useSocketStore = create<SocketState>((set, get) => ({
       const socket = get().socket;
       if (socket) socket.disconnect();
       const response = await getMindMap(mindMapId.toString());
-      set({ role: response.role });
       get().connectSocket(connectionId);
     } catch (error) {
       throw error;
     }
   },
-}));
+});

--- a/client/src/store/useConnectionStore.ts
+++ b/client/src/store/useConnectionStore.ts
@@ -1,0 +1,36 @@
+import { createRoleSlice, RoleSlice } from "@/store/createRoleSlice";
+import { createSocketSlice, SocketSlice } from "@/store/createSocketSlice";
+import { createJSONStorage, devtools, persist } from "zustand/middleware";
+import { create } from "zustand";
+import { createMindMapOwnershipSlice, MindMapOwnershipSlice } from "@/store/createMindMapOwnershipSlice";
+import { ConnectionStore } from "@/types/store";
+import { createSharedSlice } from "@/store/createSharedSlice";
+import { createAuthSlice } from "@/store/createAuthSlice";
+
+type PersistStates = {
+  token: string;
+};
+
+export const useConnectionStore = create<ConnectionStore>()(
+  devtools(
+    persist(
+      (...a) => ({
+        ...createRoleSlice(...a),
+        ...createSocketSlice(...a),
+        ...createSharedSlice(...a),
+        ...createAuthSlice(...a),
+        ...createMindMapOwnershipSlice(...a),
+      }),
+      {
+        name: "connectionStore",
+        partialize: (state) => {
+          console.log("wwwwwww");
+          return {
+            token: state.token,
+          };
+        },
+        storage: createJSONStorage(() => localStorage),
+      },
+    ),
+  ),
+);

--- a/client/src/store/useConnectionStore.ts
+++ b/client/src/store/useConnectionStore.ts
@@ -26,6 +26,8 @@ export const useConnectionStore = create<ConnectionStore>()(
         partialize: (state) => {
           return {
             token: state.token,
+            ownedMindMap: state.ownedMindMap,
+            ownedMindMapForGuest: state.ownedMindMapForGuest,
           };
         },
         storage: createJSONStorage(() => localStorage),

--- a/client/src/store/useConnectionStore.ts
+++ b/client/src/store/useConnectionStore.ts
@@ -24,7 +24,6 @@ export const useConnectionStore = create<ConnectionStore>()(
       {
         name: "connectionStore",
         partialize: (state) => {
-          console.log("wwwwwww");
           return {
             token: state.token,
           };

--- a/client/src/types/store.ts
+++ b/client/src/types/store.ts
@@ -1,0 +1,7 @@
+import { AuthSlice } from "@/store/createAuthSlice";
+import { MindMapOwnershipSlice } from "@/store/createMindMapOwnershipSlice";
+import { RoleSlice } from "@/store/createRoleSlice";
+import { SharedSlice } from "@/store/createSharedSlice";
+import { SocketSlice } from "@/store/createSocketSlice";
+
+export type ConnectionStore = RoleSlice & MindMapOwnershipSlice & SharedSlice & SocketSlice & AuthSlice;


### PR DESCRIPTION
#180 대시보드를 통해 회원과 비회원 모두 권한 관리를 갱신하며, 권한에 따라 마인드맵 상에서 가질 수 있는 수정 범위가 달라진다.
## 작업내용
### 소유권 권한 전역상태 추가
- 소유권을 회원, 비회원으로 나누어 전역상태를 관리할 수 있도록 하였습니다.
- 회원의 경우에는 대시보드에서 마인드맵 정보를 가져올 때나 갱신 때마다 소유권 확인 및 갱신할 수 있도록 하였으며, 비회원의 경우에는 처음 마인드맵을 생성할 때 갱신됩니다.
- 회원의 경우 비회원인 상태에서 로그인을 해도 대시보드로 한번은 이동하고 소유권 정보를 갱신하기 때문에 권한 문제를 해결할 수 있습니다.
```tsx
export const useConnectionStore = create<ConnectionStore>()(
  devtools(
    persist(
      (...a) => ({
        ...createRoleSlice(...a),
        ...createSocketSlice(...a),
        ...createSharedSlice(...a),
        ...createAuthSlice(...a),
        ...createMindMapOwnershipSlice(...a),
      }),
      {
        name: "connectionStore",
        partialize: (state) => {
          return {
            token: state.token,
            ownedMindMap: state.ownedMindMap,
            ownedMindMapForGuest: state.ownedMindMapForGuest,
          };
        },
        storage: createJSONStorage(() => localStorage),
      },
    ),
  ),
);
```
비회원의 경우 ownedMindMapForGuest로, 회원의 경우 ownedMindMap으로 저장 할 수 있도록 하였습니다.

### 전역 상태 slicePattern으로 리팩토링
- 기존의 전역 상태로 관리하던 socket, Auth 등은 서로 의존 관계를 가지고 있음에도 독립적으로 관리하고 있었습니다. 마인드맵 소유 권한 까지도 전역 상태로 추가됨을 기획하면서, 각 의존 관계를 가지는 상태들에 대해서 보다 통합하여 관리해야 할 필요성을 느꼈고, 이에 여러 slice로 나눈 다음에, 하나의 store에서 가져와 사용하는 slice pattern을 사용했습니다. zustand의 slice pattern은 역할 별로 나누어지는 여러가지 스토어들에 대해서 모듈성을 유지하면서도 하나의 store를 통해 관리할 수 있도록 하는 것이 목적인 만큼, 효과적인 전역 상태 관리법임을 느끼고 로직 변경을 진행했습니다.
- slicepattern으로 변경함에 따라, 각각의 store를 import해서 사용하는 것이 아닌, useConnectionStore 하나 import 해서 Selector pattern을 사용하여 가져오는 방식으로 로직 변경이 이루어졌습니다.
- 현재의 slice는 총 다섯 개로 새롭게 나누었습니다.
  - authSlice → 로그인 상태 관리를 위한 전역관리 슬라이스
  - MindMapOwnershipSlice → 마인드맵의 소유권을 관리하기 위한 슬라이스
  - RoleSlice → 현재 들어가있는 마인드맵의 역할 상태를 구분하기 위한 슬라이스
  - SharedSlice → 여러 store를 거치면서 추상화가 가능한 정도의 기능을 담은 슬라이스(현재는 createConnection을 넣어놓았습니다)
  - SocketSlice → 소켓 상태를 관리하기 위한 슬라이스
- devtools 설정을 해놓아서, redux devtools를 통해 상태 추적이 가능합니다.
[사용법은 해당 링크 들어가보시면 보실 수 있습니다.](https://ji-musclecode.tistory.com/35)

```tsx
//selector pattern은 아래와 같이 특정 상태를 가져오는 방식을 뜻합니다.
const handleSocketEvent = useConnectionStore((state) => state.handleSocketEvent);
```
connectionStore를 전부 가져오면, 해당 하는 상태들 중 하나라도 바뀌게 된다면 리렌더링이 이루어지게 되므로 최적화를 위해서 selector pattern을 사용해주세요!
컴포넌트 외부에서 사용하려면 `useConnectionStore().getState()`를 통해 가져오면 외부에서도 state에 접근할 수 있습니다.

### 마인드맵 소유권 갱신과 로그인 갱신 타이밍 문제
로그인을 해야 Id를 받을 수 있고, 이에 따른 마인드맵의 소유권을 갱신할 수 있어야 하는데, 문제는 UseAuth와 useDashboard가 함께 동작하다보니 서로 타이밍이 다르면 대시보드가 먼저 갱신될 떄가 있어 새로고침할 경우에 id가 제대로 반영되지 않아 갱신이 되지 않는 현상이 발생했습니다.

```tsx
import Spinner from "@/components/common/Spinner";
import Profile from "@/components/MindMapHeader/Profile";
import useAuth from "@/hooks/useAuth";
import { lazy, Suspense } from "react";

const DashBoard = lazy(() => import("@/components/Dashboard"));

export default function MainPage() {
  const { isLoading } = useAuth();
  return (
    <>
      {isLoading && <Spinner />}
      <header className={`flex w-full justify-end bg-transparent p-4`}>
        <Profile />
      </header>
      <main className="flex h-[90%] w-full flex-col overflow-hidden p-8">
        <p className="p-3 text-2xl font-bold">대시보드</p>
        <div className="relative flex h-[90%] w-full gap-4">
          <Suspense fallback={<Spinner />}>
            <DashBoard />
          </Suspense>
        </div>
      </main>
    </>
  );
}
```

이를 해결하기 위해 LazyLoading을 통해 타이밍 조절을 해주어 useAuth의 로징이 끝났을 때 Dashboard를 Import하여 로그인 정보 갱신 -> 마인드맵 정보 갱신 순으로 일어날 수 있게 해주었습니다.

