### PR TITLE
[Feature-3-fix-fe] 노드를 추가했을 때 input이 아닌 상태를 default로 설정 / 자동 select 조정 및 enter시 input 활성화 (리스트 영역)

### DIFF
--- a/client/src/components/MindMapCanvas/NoNodeInform.tsx
+++ b/client/src/components/MindMapCanvas/NoNodeInform.tsx
@@ -6,7 +6,7 @@ export default function NoNodeInform() {
   const { data, selectedNode, overrideNodeData, selectNode } = useNodeListContext();
   function initializeRootNode() {
     addNode(data, selectedNode, overrideNodeData, (newNodeId) => {
-      selectNode({ nodeId: newNodeId, parentNodeId: null, addTo: "canvas" });
+      selectNode({ nodeId: newNodeId, parentNodeId: null });
     });
   }
   return (

--- a/client/src/components/MindMapCanvas/ToolMenu.tsx
+++ b/client/src/components/MindMapCanvas/ToolMenu.tsx
@@ -38,14 +38,13 @@ export default function ToolMenu({ dimensions, zoomIn, zoomOut, dragmode, setDra
       selectNode({
         nodeId: newNodeId,
         parentNodeId: selectedNode.nodeId,
-        addTo: "canvas",
       });
     });
   }
   function handleDeleteButton() {
     saveHistory(JSON.stringify(data));
     deleteNodes(JSON.stringify(data), selectedNode.nodeId, overrideNodeData);
-    selectNode({ nodeId: 0, parentNodeId: 0, addTo: "canvas" });
+    selectNode({ nodeId: 0, parentNodeId: 0 });
   }
 
   return (

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -16,7 +16,6 @@ import { findRootNodeKey } from "@/konva_mindmap/utils/findRootNodeKey";
 import Konva from "konva";
 import { addNode } from "@/konva_mindmap/events/addNode";
 import { useConnectionStore } from "@/store/useConnectionStore";
-import Konva from "konva";
 
 export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
   const {

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -83,7 +83,6 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
           selectNode({
             nodeId: newNodeId,
             parentNodeId: selectedNode.nodeId,
-            addTo: "canvas",
           });
         });
         break;

--- a/client/src/components/MindMapMainSection/ControlSection/ListView/NodeItem.tsx
+++ b/client/src/components/MindMapMainSection/ControlSection/ListView/NodeItem.tsx
@@ -58,9 +58,9 @@ export default function NodeItem({ node, parentNodeId, open, handleAccordion, op
 
   function handleAddButton() {
     saveHistory(JSON.stringify(data));
-    selectNode({ nodeId: node.id, parentNodeId: parentNodeId, addTo: "list" });
-    addNode(data, { nodeId: node.id, parentNodeId: parentNodeId, addTo: "list" }, overrideNodeData, (newNodeId) => {
-      selectNode({ nodeId: newNodeId, parentNodeId: node.id, addTo: "list" });
+    selectNode({ nodeId: node.id, parentNodeId: parentNodeId });
+    addNode(data, { nodeId: node.id, parentNodeId: parentNodeId }, overrideNodeData, (newNodeId) => {
+      selectNode({ nodeId: newNodeId, parentNodeId: node.id });
     });
     openAccordion();
   }
@@ -89,7 +89,7 @@ export default function NodeItem({ node, parentNodeId, open, handleAccordion, op
 
         {isEditing ? (
           <Input
-            autoFocus={selectedNode.addTo === "list"}
+            autoFocus={true}
             ref={inputRef}
             className="flex-grow bg-transparent text-grayscale-200"
             value={keyword}

--- a/client/src/components/MindMapMainSection/ControlSection/ListView/NodeItem.tsx
+++ b/client/src/components/MindMapMainSection/ControlSection/ListView/NodeItem.tsx
@@ -59,7 +59,9 @@ export default function NodeItem({ node, parentNodeId, open, handleAccordion, op
   function handleAddButton() {
     saveHistory(JSON.stringify(data));
     selectNode({ nodeId: node.id, parentNodeId: parentNodeId, addTo: "list" });
-    addNode(data, { nodeId: node.id, parentNodeId: parentNodeId, addTo: "list" }, overrideNodeData);
+    addNode(data, { nodeId: node.id, parentNodeId: parentNodeId, addTo: "list" }, overrideNodeData, (newNodeId) => {
+      selectNode({ nodeId: newNodeId, parentNodeId: node.id, addTo: "list" });
+    });
     openAccordion();
   }
 

--- a/client/src/hooks/useNodeActions.ts
+++ b/client/src/hooks/useNodeActions.ts
@@ -8,7 +8,7 @@ export default function useNodeActions(nodeId: number, content: string) {
   const [hover, setHover] = useState<boolean>(false);
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [keyword, setKeyword] = useState(content);
-  const { data, updateNode, saveHistory, overrideNodeData } = useNodeListContext();
+  const { data, saveHistory, overrideNodeData } = useNodeListContext();
   const handleSocketEvent = useConnectionStore((state) => state.handleSocketEvent);
 
   useEffect(() => {
@@ -22,9 +22,9 @@ export default function useNodeActions(nodeId: number, content: string) {
       handleSocketEvent({
         actionType: "updateNode",
         payload: { ...data, [nodeId]: { ...data[nodeId], keyword: keyword, newNode: false } },
-        callback: () => {
+        callback: (response) => {
           saveHistory(JSON.stringify(data));
-          addNode(keyword, nodeId, updateNode);
+          overrideNodeData(response);
         },
       });
     }

--- a/client/src/konva_mindmap/components/MindMapNode.tsx
+++ b/client/src/konva_mindmap/components/MindMapNode.tsx
@@ -21,7 +21,6 @@ import { deleteNodes } from "@/konva_mindmap/events/deleteNode";
 import { useConnectionStore } from "@/store/useConnectionStore";
 import { addNode } from "@/konva_mindmap/events/addNode";
 import useWindowEventListener from "@/hooks/useWindowEventListener";
-import { useConnectionStore } from "@/store/useConnectionStore";
 
 export default function MindMapNode({ data, parentNode, node, depth, parentRef, dragmode }: NodeProps) {
   const nodeRef = useRef<Konva.Group>(null);

--- a/client/src/konva_mindmap/components/MindMapNode.tsx
+++ b/client/src/konva_mindmap/components/MindMapNode.tsx
@@ -66,10 +66,10 @@ export default function MindMapNode({ data, parentNode, node, depth, parentRef, 
   function handleClick(e: Konva.KonvaEventObject<MouseEvent>) {
     e.evt.preventDefault();
     if (selectedNode.nodeId === node.id) {
-      selectNode({ nodeId: 0, parentNodeId: 0, addTo: "canvas" });
+      selectNode({ nodeId: 0, parentNodeId: 0 });
       return;
     }
-    selectNode({ nodeId: node.id, parentNodeId: parentNode ? parentNode.id : null, addTo: "canvas" });
+    selectNode({ nodeId: node.id, parentNodeId: parentNode ? parentNode.id : null });
   }
 
   const NodeStroke = selectedGroup.includes(node.id.toString()) ? "red" : "";
@@ -138,9 +138,7 @@ export default function MindMapNode({ data, parentNode, node, depth, parentRef, 
             selectNode({});
             setIsEditing(true);
           }}
-          handleAdd={() =>
-            addNode(data, { nodeId: node.id, parentNodeId: node.id ?? null, addTo: "canvas" }, overrideNodeData)
-          }
+          handleAdd={() => addNode(data, { nodeId: node.id, parentNodeId: node.id ?? null }, overrideNodeData)}
           handleDelete={() => deleteNodes(JSON.stringify(data), node.id, overrideNodeData)}
         />
       </Group>

--- a/client/src/store/NodeListProvider.tsx
+++ b/client/src/store/NodeListProvider.tsx
@@ -18,7 +18,7 @@ export type NodeListContextType = {
   saveHistory: (newState: string) => void;
   undoData: () => void;
   redoData: () => void;
-  selectNode: ({ nodeId, parentNodeId, addTo }: SelectedNode) => void;
+  selectNode: ({ nodeId, parentNodeId }: SelectedNode) => void;
   title: string;
   updateTitle: (title: string) => void;
   groupSelect: (group: Konva.Group[]) => void;
@@ -42,7 +42,7 @@ export function useNodeListContext() {
 
 export default function NodeListProvider({ children }: { children: ReactNode }) {
   const [data, setData] = useState({});
-  const [selectedNode, setSelectedNode] = useState<SelectedNode>({ nodeId: 0, parentNodeId: 0, addTo: "canvas" });
+  const [selectedNode, setSelectedNode] = useState<SelectedNode>({ nodeId: 0, parentNodeId: 0 });
   const { saveHistory, overrideHistory, undo, redo, history } = useHistoryState<NodeData>(JSON.stringify(data));
   const { title, initializeTitle, updateTitle } = useMindMapTitle();
   const { content, updateContent, initializeContent } = useContent();
@@ -99,15 +99,14 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
     redo(setData);
   }
 
-  function selectNode({ nodeId, parentNodeId, addTo }: SelectedNode) {
+  function selectNode({ nodeId, parentNodeId }: SelectedNode) {
     if (!nodeId) {
-      setSelectedNode({ nodeId: 0, parentNodeId: 0, addTo: addTo });
+      setSelectedNode({ nodeId: 0, parentNodeId: 0 });
       return;
     }
     setSelectedNode({
       nodeId,
       parentNodeId,
-      addTo,
     });
   }
 

--- a/client/src/types/Node.ts
+++ b/client/src/types/Node.ts
@@ -16,7 +16,6 @@ export type NodeData = Record<number, Node>;
 export type SelectedNode = {
   nodeId?: number;
   parentNodeId?: number;
-  addTo?: "canvas" | "list";
 };
 
 export type NodeProps = {


### PR DESCRIPTION
## 작업 내용

### 리스트에서 노드가 추가될 경우 해당 노드로 focus가 이동
- 마인드맵에서 하던 것과 동일합니다

### 버그 수정
- 리스트 보기에서 노드 수정시 프론트엔드 상태를 업데이트하지 않고 있었습니다. updateNode 이벤트에 대한 콜백으로 넣어 뒀습니다.
- addTo 속성이 더이상 사용되지 않아 삭제하고, 이를 통해 listView의 항목들이 autofocus되지 않는 문제 (3번 클릭해야 텍스트를 입력할 수 있었던 문제)를 해결했습니다.

## 논의하고 싶은 내용
