### PR TITLE
[feature-4-fix-fe] 리스트뷰에서 input이 비어있을 경우 원래 내용으로 돌아가지 않던 문제 해결

### DIFF
--- a/client/src/hooks/useNodeActions.ts
+++ b/client/src/hooks/useNodeActions.ts
@@ -10,6 +10,7 @@ export default function useNodeActions(nodeId: number, content: string) {
   const [keyword, setKeyword] = useState(content);
   const { data, saveHistory, overrideNodeData } = useNodeListContext();
   const handleSocketEvent = useConnectionStore((state) => state.handleSocketEvent);
+  const currentJobStatus = useConnectionStore((state) => state.currentJobStatus);
 
   useEffect(() => {
     setKeyword(content);
@@ -27,6 +28,9 @@ export default function useNodeActions(nodeId: number, content: string) {
           overrideNodeData(response);
         },
       });
+      if (currentJobStatus === "error") setKeyword(originalContent);
+    } else {
+      setKeyword(originalContent);
     }
     setIsEditing(false);
   }


### PR DESCRIPTION
## 작업 내용

### 리스트뷰에서 input이 비거나 에러가 발생할 경우 원본으로 롤백
https://github.com/user-attachments/assets/8ad733fd-056e-483e-9b2a-ed0c5e5c5384

- 캔버스 영역에서와 마찬가지로 처리했습니다.

## 논의하고 싶은 내용


