### PR TITLE
[Feature-2-fe] 변환용 텍스트파일 업로드 및 오류수정

### DIFF
--- a/client/src/components/MindMapCanvas/ToolMenu.tsx
+++ b/client/src/components/MindMapCanvas/ToolMenu.tsx
@@ -72,6 +72,7 @@ export default function ToolMenu({ dimensions, zoomIn, zoomOut, dragmode, setDra
             onMouseDown={() => startZoom(zoomIn)}
             onClick={zoomIn}
             onMouseUp={stopZoom}
+            onMouseLeave={stopZoom}
           >
             <TiZoomInOutline className="h-6 w-6 fill-grayscale-400 group-hover:fill-gray-100" />
           </Button>

--- a/client/src/components/MindMapCanvas/ToolMenu.tsx
+++ b/client/src/components/MindMapCanvas/ToolMenu.tsx
@@ -19,7 +19,7 @@ type ToolMenuProps = {
   setDragmode: React.Dispatch<React.SetStateAction<boolean>>;
 };
 export default function ToolMenu({ dimensions, zoomIn, zoomOut, dragmode, setDragmode }: ToolMenuProps) {
-  const { data, selectNode, selectedNode, saveHistory, overrideNodeData } = useNodeListContext();
+  const { data, selectNode, selectedNode, saveHistory, overrideNodeData, deleteSelectedNodes } = useNodeListContext();
   const intervalRef = useRef(null);
 
   const startZoom = (zoomFn) => {

--- a/client/src/components/MindMapCanvas/index.tsx
+++ b/client/src/components/MindMapCanvas/index.tsx
@@ -29,6 +29,7 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
     deleteSelectedNodes,
     selectedNode,
     selectNode,
+    groupRelease,
   } = useNodeListContext();
   const [isDragMode, setDragMode] = useState(false);
   const { dimensions, targetRef, handleWheel, zoomIn, zoomOut, reArrange } = useDimension(data);
@@ -85,6 +86,10 @@ export default function MindMapCanvas({ showMinutes, handleShowMinutes }) {
             parentNodeId: selectedNode.nodeId,
           });
         });
+        break;
+      case "Escape":
+        groupRelease();
+        selectNode({});
         break;
       default:
         break;

--- a/client/src/components/MindMapHeader/index.tsx
+++ b/client/src/components/MindMapHeader/index.tsx
@@ -11,7 +11,6 @@ import { FaPencilAlt } from "react-icons/fa";
 
 export default function MindMapHeader() {
   const { title, updateTitle } = useNodeListContext();
-  const { isLoading } = useAuth();
   const [editMode, setEditMode] = useState(false);
   const handleSocketEvent = useConnectionStore((state) => state.handleSocketEvent);
   const [editTitle, setEditTitle] = useState(title);
@@ -57,7 +56,6 @@ export default function MindMapHeader() {
         </span>
       )}
       <Profile />
-      {isLoading && createPortal(<Spinner />, document.body)}
     </header>
   );
 }

--- a/client/src/components/MindMapMainSection/ControlSection/TextUpload.tsx
+++ b/client/src/components/MindMapMainSection/ControlSection/TextUpload.tsx
@@ -1,10 +1,22 @@
-import { TEXT_UPLOAD_LIMIT } from "@/constants/textUploadLimit";
+import ArrowBox from "@/components/common/ArrowBox";
+import Spinner from "@/components/common/Spinner";
+import { MAX_TEXT_UPLOAD_LIMIT } from "@/constants/textUploadLimit";
+import useUpload from "@/hooks/useUpload";
 import { Button, Textarea } from "@headlessui/react";
-import { useState } from "react";
+import { createPortal } from "react-dom";
 import clovaX from "@/assets/clovaX.png";
 
 export default function TextUpload() {
-  const [content, setContent] = useState("");
+  const {
+    content,
+    aiProcessing,
+    buttonAvailability,
+    updateContent,
+    handleAiProcessButton,
+    availabilityInformBox,
+    handleMouseEnter,
+    handleMouseLeave,
+  } = useUpload();
 
   return (
     <div className="flex h-full flex-col gap-6 text-grayscale-100">
@@ -18,10 +30,27 @@ export default function TextUpload() {
           maxLength={TEXT_UPLOAD_LIMIT}
         />
         <p className="text-right text-grayscale-400">
-          {content.length}/{TEXT_UPLOAD_LIMIT}
+          {content.length}/{MAX_TEXT_UPLOAD_LIMIT}
         </p>
       </div>
-      <Button className="rounded-xl bg-bm-blue p-3 transition hover:brightness-90">만들기</Button>
+      <Button
+        className="relative rounded-xl bg-bm-blue p-3 transition hover:brightness-90"
+        onClick={handleAiProcessButton}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        만들기
+        {availabilityInformBox && (
+          <ArrowBox
+            containerClassName="-left-0.5 -top-10 w-full text-sm"
+            boxClassName="bg-grayscale-500 p-1"
+            arrowClassName="bottom-0 left-1/2 z-0 h-3 w-3 -translate-x-1/2 translate-y-1/2 rotate-45 bg-grayscale-500"
+          >
+            <p>마인드맵을 소유한 사람만 ai 변환을 사용할 수 있어요</p>
+          </ArrowBox>
+        )}
+      </Button>
+      {aiProcessing && createPortal(<Spinner />, document.body)}
       <div className="flex w-48 justify-end">
         <img src={clovaX} alt="clovaX" />
       </div>

--- a/client/src/components/MindMapMainSection/ControlSection/TextUpload.tsx
+++ b/client/src/components/MindMapMainSection/ControlSection/TextUpload.tsx
@@ -26,8 +26,8 @@ export default function TextUpload() {
           className="h-full w-full resize-none rounded-xl bg-grayscale-600 p-4"
           placeholder="Text를 넣어주세요. (500자 이상 2000자 이하)"
           onKeyDown={(e) => e.stopPropagation()}
-          onChange={(e) => setContent(e.target.value)}
-          maxLength={TEXT_UPLOAD_LIMIT}
+          onChange={(e) => updateContent(e.target.value)}
+          maxLength={MAX_TEXT_UPLOAD_LIMIT}
         />
         <p className="text-right text-grayscale-400">
           {content.length}/{MAX_TEXT_UPLOAD_LIMIT}

--- a/client/src/components/common/ArrowBox.tsx
+++ b/client/src/components/common/ArrowBox.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from "react";
+
+export default function ArrowBox({
+  children,
+  containerClassName,
+  boxClassName,
+  arrowClassName,
+}: {
+  children: ReactNode;
+  containerClassName: string;
+  boxClassName: string;
+  arrowClassName: string;
+}) {
+  return (
+    <div className={`absolute ${containerClassName} -left-0.5 -top-10 w-full text-sm`}>
+      <div className={`relative rounded-md ${boxClassName} bg-grayscale-500 p-1`}>
+        {children}
+        <div className={`absolute ${arrowClassName} transform`}></div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/constants/textUploadLimit.ts
+++ b/client/src/constants/textUploadLimit.ts
@@ -1,1 +1,2 @@
-export const TEXT_UPLOAD_LIMIT = 2000;
+export const MAX_TEXT_UPLOAD_LIMIT = 2000;
+export const MIN_TEXT_UPLOAD_LIMIT = 500;

--- a/client/src/hooks/useUpload.ts
+++ b/client/src/hooks/useUpload.ts
@@ -1,0 +1,45 @@
+import { MIN_TEXT_UPLOAD_LIMIT } from "@/constants/textUploadLimit";
+import { useConnectionStore } from "@/store/useConnectionStore";
+import { useState } from "react";
+
+export default function useUpload() {
+  const [content, setContent] = useState("");
+  const [aiProcessing, setAiProcessing] = useState(false);
+  const role = useConnectionStore((state) => state.currentRole);
+  const socket = useConnectionStore((state) => state.socket);
+  const handleSocketEvent = useConnectionStore((state) => state.handleSocketEvent);
+  const [availabilityInformBox, setAvailabilityInformBox] = useState(false);
+
+  const buttonAvailability = role === "owner";
+
+  socket?.on("aiPending", (response) => {
+    setAiProcessing(response.status);
+  });
+
+  function handleAiProcessButton() {
+    if (content.length <= MIN_TEXT_UPLOAD_LIMIT || !buttonAvailability) return;
+    handleSocketEvent({ actionType: "aiRequest", payload: { aiContent: content } });
+  }
+
+  function updateContent(content: string) {
+    setContent(content);
+  }
+
+  function handleMouseEnter() {
+    if (!buttonAvailability) setAvailabilityInformBox(true);
+  }
+  function handleMouseLeave() {
+    setAvailabilityInformBox(false);
+  }
+
+  return {
+    content,
+    updateContent,
+    aiProcessing,
+    buttonAvailability,
+    handleAiProcessButton,
+    availabilityInformBox,
+    handleMouseEnter,
+    handleMouseLeave,
+  };
+}

--- a/client/src/konva_mindmap/components/EditableText.tsx
+++ b/client/src/konva_mindmap/components/EditableText.tsx
@@ -58,7 +58,7 @@ export default function EditableText({
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     e.stopPropagation();
-    if (e.key === "Enter") setIsEditing(false);
+    if (e.key === "Enter" || e.code === "Escape") setIsEditing(false);
   }
 
   function handleBlur() {

--- a/client/src/konva_mindmap/events/deleteNode.ts
+++ b/client/src/konva_mindmap/events/deleteNode.ts
@@ -6,7 +6,10 @@ export function deleteNodes(data: string, selectedNodeIds: number | number[], ov
   const newNodeData: NodeData = JSON.parse(data);
   const rootKey = findRootNodeKey(newNodeData);
 
-  if ((Array.isArray(selectedNodeIds) && selectedNodeIds.includes(rootKey)) || selectedNodeIds === rootKey) return;
+  if (Array.isArray(selectedNodeIds) && selectedNodeIds.includes(rootKey)) {
+    return deleteNodes(data, [...newNodeData[rootKey].children], overrideNodeData);
+  }
+  if (!Array.isArray(selectedNodeIds) && selectedNodeIds === rootKey) return;
 
   const nodeIds = Array.isArray(selectedNodeIds) ? selectedNodeIds : [selectedNodeIds];
   if (nodeIds.some((id) => !id || !newNodeData[id])) return;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, Suspense } from "react";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
@@ -11,7 +11,6 @@ import MindMap from "@/pages/Mindmap";
 import { ErrorBoundary } from "react-error-boundary";
 import { useConnectionStore } from "@/store/useConnectionStore";
 import TestPage from "./pages/TestPage";
-import Spinner from "@/components/common/Spinner";
 
 const router = createBrowserRouter([
   {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode } from "react";
+import { StrictMode, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
@@ -11,6 +11,7 @@ import MindMap from "@/pages/Mindmap";
 import { ErrorBoundary } from "react-error-boundary";
 import { useConnectionStore } from "@/store/useConnectionStore";
 import TestPage from "./pages/TestPage";
+import Spinner from "@/components/common/Spinner";
 
 const router = createBrowserRouter([
   {

--- a/client/src/pages/Mindmap/index.tsx
+++ b/client/src/pages/Mindmap/index.tsx
@@ -1,12 +1,22 @@
-import MindMapMainSection from "@/components/MindMapMainSection";
+import Spinner from "@/components/common/Spinner";
+import useAuth from "@/hooks/useAuth";
 import NodeListProvider from "@/store/NodeListProvider";
+import { lazy, Suspense } from "react";
+
+const MindMapMainSection = lazy(() => import("@/components/MindMapMainSection"));
 
 export default function MindMap() {
+  const { isLoading } = useAuth();
+  if (isLoading) return <Spinner />;
   return (
-    <div className="flex h-full w-full flex-col">
-      <NodeListProvider>
-        <MindMapMainSection />
-      </NodeListProvider>
-    </div>
+    <>
+      <div className="flex h-full w-full flex-col">
+        <NodeListProvider>
+          <Suspense fallback={<Spinner />}>
+            <MindMapMainSection />
+          </Suspense>
+        </NodeListProvider>
+      </div>
+    </>
   );
 }

--- a/client/src/store/NodeListProvider.tsx
+++ b/client/src/store/NodeListProvider.tsx
@@ -8,6 +8,7 @@ import { setLatestMindMap } from "@/utils/localstorage";
 import useMindMapTitle from "@/hooks/useMindMapTitle";
 import useContent from "@/hooks/useContent";
 import { useConnectionStore } from "@/store/useConnectionStore";
+import initializeNodePosition from "@/konva_mindmap/utils/initializeNodePosition";
 
 export type NodeListContextType = {
   data: NodeData | null;
@@ -50,6 +51,7 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
   const [mindMapId, setMindMapId] = useState("");
   const { selectedGroup, groupRelease, groupSelect } = useGroupSelect();
   const socket = useConnectionStore((state) => state.socket);
+  const handleSocketEvent = useConnectionStore((state) => state.handleSocketEvent);
 
   socket?.on("joinRoom", (initialData) => {
     setLoading(true);
@@ -78,6 +80,11 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
     setData({});
     overrideHistory(JSON.stringify({}));
     setLatestMindMap(mindMapId);
+  });
+
+  socket?.on("aiResponse", (response) => {
+    const initializedNodes = initializeNodePosition(response.nodeData);
+    handleSocketEvent({ actionType: "updateNode", payload: initializedNodes });
   });
 
   function updateNode(id: number, updatedNode: Partial<Node>) {

--- a/client/src/store/createSocketSlice.ts
+++ b/client/src/store/createSocketSlice.ts
@@ -1,13 +1,6 @@
 import { Socket, io } from "socket.io-client";
 import { StateCreator } from "zustand";
-import {
-  actionType,
-  createNodePayload,
-  updateNodePayload,
-  deleteNodePayload,
-  updateTitlePayload,
-  updateContentPayload,
-} from "@/types/NodePayload";
+import { actionType, HandleSocketEventPayloads } from "@/types/NodePayload";
 import { createMindmap, getMindMap } from "@/api/mindmap.api";
 import { ConnectionStore } from "@/types/store";
 
@@ -25,7 +18,7 @@ export type SocketSlice = {
 
 type HandleSocketEventProps = {
   actionType: actionType;
-  payload: createNodePayload | updateNodePayload | deleteNodePayload | updateTitlePayload | updateContentPayload;
+  payload: HandleSocketEventPayloads;
   callback?: (response?: any) => void;
 };
 

--- a/client/src/types/NodePayload.ts
+++ b/client/src/types/NodePayload.ts
@@ -1,8 +1,16 @@
 import { NodeData } from "./Node";
 
-export type actionType = "createNode" | "deleteNode" | "updateNode" | "updateTitle" | "updateContent";
+export type actionType = "createNode" | "deleteNode" | "updateNode" | "updateTitle" | "updateContent" | "aiRequest";
 
-export type createNodePayload = {
+export type HandleSocketEventPayloads =
+  | createNodePayload
+  | deleteNodePayload
+  | updateNodePayload
+  | updateContentPayload
+  | updateTitlePayload
+  | aiRequestPayload;
+
+type createNodePayload = {
   id: number;
   keyword: string;
   depth: number;
@@ -12,11 +20,12 @@ export type createNodePayload = {
   parentId: number | null;
 };
 
-export type deleteNodePayload = {
+type deleteNodePayload = {
   id: string[];
 };
 
-export type updateNodePayload = NodeData;
+type updateNodePayload = NodeData;
 
-export type updateTitlePayload = { title: string };
-export type updateContentPayload = { content: string };
+type updateTitlePayload = { title: string };
+type updateContentPayload = { content: string };
+type aiRequestPayload = { aiContent: string };


### PR DESCRIPTION
이슈번호 : #12 #47 #188 변환용 텍스트파일 업로드 관련
---
## 작업내용
- aiRequest와 response, aiPending 관련 소켓 이벤트를 추가했습니다. 아직 서버와의 테스트는 안되었기 때문에 테스트 후 조정할 필요가 있습니다.
- 소유권자가 아닐 경우, 안내 말풍선이 버튼 위로 뜰 수 있도록 하였습니다.
  - 추가적으로 말풍선 컴포넌트를 만들어 containerClassName: absolute주는영역 스타일  boxClassName: 말풍선 컨테이너 영역 스타일,  arrowClassName: 말풍선의 화살표 스타일을 지정할 수 있도록 해놓았습니다.
<img width="363" alt="스크린샷 2024-12-01 오후 3 45 19" src="https://github.com/user-attachments/assets/a6f60e23-5a1f-4295-91a8-fc6b93561772">

- 최소 최대 텍스트 입력 제한 상수명을 추가 및 변경했습니다.
- Escape를 누르면 그룹 선택이 취소되고, input이 활성화된 상태이면 blur처리 될 수 있도록 하였습니다.
- 그룹 선택에서 루트 노드를 포함하고 삭제를 누르면 루트를 제외한 루트의 children들이 모두 삭제 처리될 수 있도록 하였습니다.

### Fix
- 툴 메뉴의 확대 버튼 클릭 상태에서 나가게 되면 줌인이 계속되는 오류를 해결했습니다.
- 그룹을 선택하고 아래 툴 메뉴에서 삭제 버튼을 누르면 동작하지 않는 오류를 해결했습니다.