### PR TITLE
[Feature-3-19-fe-fix] 소유권 관련 문제 및 제목 수정 오류 해결

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -59,6 +59,7 @@ instance.interceptors.response.use(
 
           return instance(originalRequest);
         }
+        useConnectionStore.getState().logout();
         return Promise.reject(error);
       }
 

--- a/client/src/components/MindMapHeader/Profile.tsx
+++ b/client/src/components/MindMapHeader/Profile.tsx
@@ -11,9 +11,10 @@ export default function Profile() {
   const { open: profileModal, openModal: openProfileModal, closeModal: closeProfileModal } = useModal();
   const isAuthenticated = useConnectionStore((state) => state.token);
 
-  function handleProfileModal() {
+  function handleProfileModal(e) {
+    e.stopPropagation();
     if (isAuthenticated) {
-      openProfileModal();
+      profileModal ? closeProfileModal() : openProfileModal();
       return;
     }
     openLoginModal();

--- a/client/src/components/MindMapHeader/ProfileModal.tsx
+++ b/client/src/components/MindMapHeader/ProfileModal.tsx
@@ -29,11 +29,11 @@ export default function ProfileModal({ open, close }: ProfileModalProps) {
     };
 
     if (open) {
-      document.addEventListener("mousedown", handleClickOutside);
+      document.addEventListener("click", handleClickOutside);
     }
 
     return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("click", handleClickOutside);
     };
   }, [open, close]);
 

--- a/client/src/components/MindMapHeader/index.tsx
+++ b/client/src/components/MindMapHeader/index.tsx
@@ -26,6 +26,10 @@ export default function MindMapHeader() {
     handleSocketEvent({
       actionType: "updateTitle",
       payload: { title: editTitle },
+      callback: (response) => {
+        updateTitle(response.title);
+        setEditTitle(response.title);
+      },
     });
     setEditMode(false);
   }

--- a/client/src/constants/color.ts
+++ b/client/src/constants/color.ts
@@ -1,1 +1,1 @@
-export const colors = ["skyblue", "lightgreen", "lightcoral", "purple", "lemonchiffon"];
+export const colors = ["#0053B5", "#64B5F6", "#6B95BC", "#E6F4F1", "#FCFCD4"];

--- a/client/src/konva_mindmap/components/MindMapNode.tsx
+++ b/client/src/konva_mindmap/components/MindMapNode.tsx
@@ -72,7 +72,7 @@ export default function MindMapNode({ data, parentNode, node, depth, parentRef, 
     selectNode({ nodeId: node.id, parentNodeId: parentNode ? parentNode.id : null });
   }
 
-  const NodeStroke = selectedGroup.includes(node.id.toString()) ? "red" : "";
+  const NodeStroke = selectedGroup.includes(node.id.toString()) ? "#cb575f" : "";
 
   const handleDragMove = (e: Konva.KonvaEventObject<DragEvent>) => {
     e.evt.preventDefault();
@@ -114,12 +114,11 @@ export default function MindMapNode({ data, parentNode, node, depth, parentRef, 
       >
         <Circle
           stroke={NodeStroke}
-          fill={selectedNode?.nodeId === node.id ? "orange" : colors[depth - 1]}
+          fill={selectedNode?.nodeId === node.id ? "#EE92BA" : colors[depth - 1]}
           width={NODE_WIDTH_AND_HEIGHT}
           height={NODE_WIDTH_AND_HEIGHT}
-          strokeWidth={3}
+          strokeWidth={5}
           radius={NODE_RADIUS(depth)}
-          shadowBlur={5}
         />
         <EditableText
           id={node.id}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -56,7 +56,6 @@ queryClient.getQueryCache().subscribe((event) => {
   if (event?.type === "updated" && event.query.queryKey[0] === "user") {
     const data = event.query.state.data;
     if (data?.email && data?.name && data?.id) useConnectionStore.getState().setUser(data?.email, data?.name, data?.id);
-    else useConnectionStore.getState().logout();
   }
 });
 

--- a/client/src/store/createMindMapOwnershipSlice.ts
+++ b/client/src/store/createMindMapOwnershipSlice.ts
@@ -26,6 +26,7 @@ export const createMindMapOwnershipSlice: StateCreator<ConnectionStore, [], [], 
 
   updateOwnedMindMap: (mindMaps: DashBoard[]) => {
     const userId = get().id;
+    if (!userId) return;
     const userOwnedMaps = mindMaps.filter((map) => map.ownerId === userId).map((map) => map.connectionId);
     set({ ownedMindMap: userOwnedMaps });
   },
@@ -33,7 +34,9 @@ export const createMindMapOwnershipSlice: StateCreator<ConnectionStore, [], [], 
   deleteOwnedMindMap: (connectionId: string) =>
     set((state) => ({ ownedMindMap: state.ownedMindMap.filter((map) => map !== connectionId) })),
   deleteOwnedMindMapForGuest: (connectionId: string) =>
-    set((state) => ({ ownedMindMap: state.ownedMindMap.filter((map) => map !== connectionId) })),
+    set((state) => ({
+      ownedMindMapForGuest: state.ownedMindMapForGuest.filter((map) => map !== connectionId),
+    })),
 
   resetOwnedMindMap: () => set({ ownedMindMap: [] }),
 });


### PR DESCRIPTION
## 작업 내용
- 소유권 관련 문제를 해결했습니다.
  - react-query상에서 user/Info에 대해서 상태 업데이트시마다 구독한 콜백이 있는데, 여기서 401에러가 뜨면 로그아웃 처리가 되면서 맵이 초기화되던 문제였습니다.
- 소유권자의 경우 제목 수정 socket 이벤트가 response로 오기 때문에 이에 따른 제목과 수정 텍스트 상태를 업데이트 할 수 있도록 해주었습니다.
