### PR TITLE
[feature-be-fix] 마인드맵 삭제 시 관련 자식 데이터 삭제 오류 수정

### DIFF
--- a/BE/apps/api-server/src/modules/mindmap/mindmap.service.ts
+++ b/BE/apps/api-server/src/modules/mindmap/mindmap.service.ts
@@ -84,8 +84,14 @@ export class MindmapService {
       throw new UnauthorizedException('권한이 없습니다.');
     }
 
-    await this.mindmapRepository.softRemove({ id: mindmapId });
-    await this.userMindmapRoleRepository.softDelete({ mindmap: { id: mindmapId } });
+    const mindmap = await this.mindmapRepository.findOne({
+      where: { id: mindmapId },
+      relations: ['nodes', 'userMindmapRoles'],
+    });
+    if (!mindmap) {
+      throw new MindmapException('마인드맵을 찾을 수 없습니다.');
+    }
+    await this.mindmapRepository.softRemove(mindmap);
   }
 
   async getDataByMindmapId(mindmapId: number) {


### PR DESCRIPTION
## 작업 내용
- typeORM의 softDelete의 cascade를 적용하려면 softRemove할 엔티티를 조회할 때 relations로 관련 테이블도 같이 조회한 뒤 softRemove를 해야 cascade가 적용이 된다.

## 논의하고 싶은 내용
