### PR TITLE
[feature-historyState-fix] history에 빈 객체가 있을 경우 접근 방지

### DIFF
--- a/client/src/hooks/useHistoryState.ts
+++ b/client/src/hooks/useHistoryState.ts
@@ -26,6 +26,7 @@ export default function useHistoryState<T>(data: string) {
     (setData) => {
       if (!history[0] || pointer <= 0) return;
       const parsedData = JSON.parse(history[pointer - 1]);
+      if (Object.keys(parsedData).length === 0) return;
       handleSocketEvent({
         actionType: "updateNode",
         payload: parsedData,


### PR DESCRIPTION
## 작업 내용
- root 노드... 삭제 되면 안 되니까요...

## 논의하고 싶은 내용
