### PR TITLE
[Feature-socket-fix] 소켓이 잘못된 핸들러를 없애 이벤트 수신 및 반영이 안 되던 문제 해결

### DIFF
--- a/client/src/store/NodeListProvider.tsx
+++ b/client/src/store/NodeListProvider.tsx
@@ -90,7 +90,7 @@ export default function NodeListProvider({ children }: { children: ReactNode }) 
         });
       },
       updateNode: (updatedNodeData) => {
-        overrideNodeData(updatedNodeData);
+        setData(updatedNodeData);
       },
       updateTitle: (updatedTitle) => {
         updateTitle(updatedTitle.title);

--- a/client/src/store/createSocketSlice.ts
+++ b/client/src/store/createSocketSlice.ts
@@ -87,14 +87,13 @@ export const createSocketSlice: StateCreator<ConnectionStore, [], [], SocketSlic
   handleSocketEvent: ({ actionType, payload, callback }: HandleSocketEventProps) => {
     const socket = get().socket;
     if (!socket) return;
-
-    socket.off(actionType);
-    socket.emit(actionType, payload);
-
-    socket.on(actionType, (response) => {
+    const handler = (response) => {
       if (response && callback) callback(response);
       set({ currentJobStatus: "success" });
-    });
+      socket.off(actionType, handler);
+    };
+    socket.on(actionType, handler);
+    socket.emit(actionType, payload);
   },
 
   handleConnection: async () => {


### PR DESCRIPTION
## 작업 내용
### 소켓이 잘못된 핸들러를 없애 이벤트 수신 및 반영이 안 되던 문제 해결
이런 문제가 있었습니다.

```
  A랑 B 창을 열고, 같은 링크에서 작업
  A가 노드를 조작하고, B의 화면에 내용이 반영이 됨
  그 다음에 B가 노드를 조작하면 A의 화면에 반영이 안 됨
  그 이후 A나 B가 노드를 조작하면 둘 다 자기 화면에만 반영이 됨
```
`handleSocketEvent`에서 `off`를 할 때 모든 리스너가 사라져 서버의 response를 상시로 listen해야 하는 리스너까지 함께 사라지기 때문에 발생하는 문제임을 파악했습니다. 해당 부분 수정하여 올립니다

### 약간의 리팩토링

## 논의하고 싶은 내용
